### PR TITLE
add property to control eec enrichment for logs

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Dynatrace LLC
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/dynatrace_extension/sdk/communication.py
+++ b/dynatrace_extension/sdk/communication.py
@@ -92,7 +92,7 @@ class CommunicationClient(ABC):
         pass
 
     @abstractmethod
-    def send_events(self, event: dict | list[dict]) -> dict | None:
+    def send_events(self, event: dict | list[dict], eec_enrichment: bool) -> dict | None:
         pass
 
     @abstractmethod
@@ -275,13 +275,16 @@ class HttpClient(CommunicationClient):
             responses.append(mint_response)
         return responses
 
-    def send_events(self, events: dict | list[dict]) -> dict | None:
+    def send_events(self, events: dict | list[dict], eec_enrichment: bool = True) -> dict | None:
         self.logger.debug(f"Sending log events: {events}")
         event_data = json.dumps(events).encode("utf-8")
         try:
             # EEC returns empty body on success
             return self._make_request(
-                self._events_url, "POST", event_data, extra_headers={"Content-Type": CONTENT_TYPE_JSON}
+                self._events_url,
+                "POST",
+                event_data,
+                extra_headers={"Content-Type": CONTENT_TYPE_JSON, "eec-enrichment": str(eec_enrichment).lower()},
             ).json()
         except json.JSONDecodeError:
             return None
@@ -394,8 +397,8 @@ class DebugClient(CommunicationClient):
             responses = [MintResponse(lines_invalid=0, lines_ok=len(mint_lines), error=None, warnings=None)]
         return responses
 
-    def send_events(self, events: dict | list[dict]) -> dict | None:
-        self.logger.info(f"send_events: {events}")
+    def send_events(self, events: dict | list[dict], eec_enrichment: bool = True) -> dict | None:
+        self.logger.info(f"send_events (enrichment = {eec_enrichment}): {events}")
         return None
 
     def send_sfm_metrics(self, mint_lines: list[str]) -> MintResponse:

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -173,6 +173,9 @@ class Extension:
         self._task_id = "development_task_id"
         self._monitoring_config_id = "development_config_id"
 
+        # The user can override default EEC enrichment for logs
+        self.log_event_enrichment = True
+
         # The Communication client
         self._client: CommunicationClient = None  # type: ignore
 
@@ -984,7 +987,7 @@ class Extension:
             self._metrics.extend(lines)
 
     def _send_events_internal(self, events: Union[dict, List[dict]]):
-        response = self._client.send_events(events)
+        response = self._client.send_events(events, self.log_event_enrichment)
         with self._internal_callbacks_results_lock:
             self._internal_callbacks_results[self._send_events.__name__] = Status(StatusValue.OK)
             if not response or "error" not in response or "message" not in response["error"]:


### PR DESCRIPTION
I've added a `bool` property at Extension level (`self.log_event_enrichment`) to control whether we want log events and log lines to be enriched by the EEC or not.

CommunicationClient and DebugClient now also have a `eec_encrichment` argument so this value can be passed on.

The effect is that we have an `eec-enrichment` header on send_events requests to reflect the value as needed.

Tests are still weird for me, so looking for guidance if this PR needs more attention.