### PR TITLE
Fix default feature set not being enabled by default

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Dynatrace LLC
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.8"
+__version__ = "1.1.9"

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -655,7 +655,7 @@ class Extension:
         return {
             feature_set_name: metric_keys
             for feature_set_name, metric_keys in self._feature_sets.items()
-            if feature_set_name in self.activation_config.feature_sets
+            if feature_set_name in self.activation_config.feature_sets or feature_set_name == "default"
         }
 
     @property
@@ -665,7 +665,7 @@ class Extension:
         Returns:
             List containing names of enabled feature sets.
         """
-        return self.activation_config.feature_sets
+        return list(self.enabled_feature_sets.keys())
 
     @property
     def enabled_feature_sets_metrics(self) -> list[str]:

--- a/tests/sdk/test_extension.py
+++ b/tests/sdk/test_extension.py
@@ -651,6 +651,7 @@ class TestExtension(unittest.TestCase):
             "set1": ["metric1set1", "metric2set1"],
             "set2": ["metric1set2"],
             "set3": ["metric1set3", "metric2set3", "metric3set3"],
+            "default": ["metric1default", "metric2default"]
         }
 
         activation_config_dict = {
@@ -665,11 +666,14 @@ class TestExtension(unittest.TestCase):
 
         activation_config = ActivationConfig(activation_config_dict)
 
-        correct_enabled_feature_sets_names = ["set2", "set1"]
+        correct_enabled_feature_sets_names = ["set1", "set2", "default"]
 
-        correct_enabled_feature_sets = {"set1": ["metric1set1", "metric2set1"], "set2": ["metric1set2"]}
+        correct_enabled_feature_sets = {"set1": ["metric1set1", "metric2set1"],
+                                        "set2": ["metric1set2"],
+                                        "default": ["metric1default", "metric2default"]}
 
-        correct_enabled_feature_sets_metrics = ["metric1set1", "metric2set1", "metric1set2"]
+        correct_enabled_feature_sets_metrics = ["metric1set1", "metric2set1", "metric1set2",
+                                                "metric1default", "metric2default"]
 
         ext._feature_sets = feature_sets
         ext.activation_config = activation_config


### PR DESCRIPTION
When creating configs via 3rd-gen UI, `default` feature set is not explicitly passed in activation, hence it needs to be enabled by default on the extension side.