### PR TITLE
Remove trailing slash from upload command

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Dynatrace LLC
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.10"
+__version__ = "1.1.11"

--- a/dynatrace_extension/cli/main.py
+++ b/dynatrace_extension/cli/main.py
@@ -292,6 +292,8 @@ def upload(
         zip_file_path = Path(extension_path, "dist", zip_file_name)
 
     api_url = tenant_url or os.environ.get("DT_API_URL", "")
+    api_url = api_url.rstrip("/")
+
     if not api_url:
         console.print("Set the --tenant-url parameter or the DT_API_URL environment variable", style="bold red")
         sys.exit(1)


### PR DESCRIPTION
Uploading with a trailing slash causes dt-cli to incorrectly states that an extension was uploaded successfully because Dynatrace will return HTTP 200.