### PR TITLE
Fix issue with the metrics lock, add --no-print-metrics option

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Dynatrace LLC
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.10"
+__version__ = "1.1.11"

--- a/dynatrace_extension/cli/main.py
+++ b/dynatrace_extension/cli/main.py
@@ -38,6 +38,7 @@ def run(
     fast_check: bool = typer.Option(False, "--fastcheck"),
     local_ingest: bool = typer.Option(False, "--local-ingest"),
     local_ingest_port: int = typer.Option(14499, "--local-ingest-port"),
+    print_metrics: bool = typer.Option(True),
 ):
     """
     Runs an extension, this is used during development to locally run and test an extension
@@ -47,6 +48,7 @@ def run(
     :param fast_check: If true, run a fastcheck and exits
     :param local_ingest: If true, send metrics to localhost:14499 on top of printing them
     :param local_ingest_port: The port to send metrics to, by default this is 14499
+    :param print_metrics: If true, print metrics to the console
     """
 
     # This parses the yaml, which validates it before running
@@ -58,6 +60,8 @@ def run(
         if local_ingest:
             command.append("--local-ingest")
             command.append(f"--local-ingest-port={local_ingest_port}")
+        if not print_metrics:
+            command.append("--no-print-metrics")
         run_process(command, cwd=extension_dir)
     except KeyboardInterrupt:
         console.print("\nRun interrupted with a KeyboardInterrupt, stopping", style="bold yellow")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ dependencies = [
     "dt-cli",
     "typer[all]",
     "pyyaml",
+    "tomli"
 ]
 
 [tool.hatch.envs.docs.env-vars]


### PR DESCRIPTION
Some time ago this line:

```
with self._metrics_lock:
```

was replaced with this line:

```
with self._metrics_lock and self._internal_callbacks_results_lock:
```

This meant that this block was the same as:

```
with True:
```

Completely negating the purpose of the lock, and allowing threads to modify the list of metrics while it was being flushed. And even worse, it allowed the list of metrics to be deleted after other threads have added metrics to it.

This fixes the lock.

It also adds the option `--no-print-metrics` to `dt-sdk run`, a useful flag to have for extensions that report a large number of metrics.

There is also a fix for the docs build as documented [here](https://www.sphinx-doc.org/en/master/changes.html#release-7-3-1-released-apr-17-2024)