### PR TITLE
Fix docs building #41 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ packages = ["dynatrace_extension"]
 dependencies = [
     "coverage[toml]>=6.5",
     "pytest",
-    "typer",
+    "typer[all]",
     "pyyaml",
     "dt-cli>=1.6.13"
 ]
@@ -73,7 +73,7 @@ dependencies = [
     "black>=23.1.0",
     "mypy>=1.0.0",
     "ruff>=0.0.243",
-    "typer",
+    "typer[all]",
     "pyyaml"
 ]
 
@@ -100,7 +100,7 @@ dependencies = [
     "sphinxcontrib-programoutput",
     "wutch",
     "dt-cli",
-    "typer",
+    "typer[all]",
     "pyyaml",
     "tomli"
 ]


### PR DESCRIPTION
Typer removed the rich dependency recently, we will keep the `typer[all]` for now and investigate later which individual libs we need to use `typer` only

Fix #41 