### PR TITLE
Remove unused code

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "1.1.13"
+__version__ = "1.1.14"

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -769,7 +769,7 @@ class Extension:
                 current_thread_id = threading.get_ident()
                 self._running_callbacks[current_thread_id] = callback
 
-            callback(self.activation_config, self.extension_config)
+            callback()
 
             with self._sfm_metrics_lock:
                 self._callbackSfmReport[callback.name()] = callback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ packages = ["dynatrace_extension"]
 [tool.hatch.envs.default]
 dependencies = [
     "coverage[toml]>=6.5",
+    "dt-cli>=1.6.13",
     "pytest",
     "typer[all]",
     "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ packages = ["dynatrace_extension"]
 [tool.hatch.envs.default]
 dependencies = [
     "coverage[toml]>=6.5",
-    "dt-cli>=1.6.13",
     "pytest",
     "typer[all]",
     "pyyaml",


### PR DESCRIPTION
At some point we added 2 keyword arguments to the callbacks.

That is never used, it is also not necessary because they are already part of the extension.