### PR TITLE
bumped minimum python version to 3.10

### DIFF
--- a/docs/guides/extension_structure.rst
+++ b/docs/guides/extension_structure.rst
@@ -41,7 +41,7 @@ Here is what a sample extension definition looks like:
       runtime:
         module: my_extension
         version:
-          min: "3.9"
+          min: "3.10"
 
       activation:
         remote:

--- a/dynatrace_extension/cli/create/extension_template/extension/extension.yaml.template
+++ b/dynatrace_extension/cli/create/extension_template/extension/extension.yaml.template
@@ -8,7 +8,7 @@ python:
   runtime:
     module: %extension_name%
     version:
-      min: "3.9"
+      min: "3.10"
 
   activation:
     remote:

--- a/tests/cli/test_types.py
+++ b/tests/cli/test_types.py
@@ -16,7 +16,7 @@ python:
   runtime:
     module: mulesoft_cloudhub
     version:
-      min: "3.9"
+      min: "3.10"
 
   activation:
     remote:
@@ -38,7 +38,7 @@ class TestTypes(TestCase):
         assert extension.min_dynatrace_version == "1.902"
         assert extension.author.name == "Dynatrace"
         assert extension.python.runtime.module == "mulesoft_cloudhub"
-        assert extension.python.runtime.version.min_version == "3.9"
+        assert extension.python.runtime.version.min_version == "3.10"
         assert extension.python.activation.remote.path == "activationSchema.json"
         assert extension.python.activation.local is None
 


### PR DESCRIPTION
Given the Dynatrace ActiveGate ships with python 3.10, it makes sense that this should also be the default minimum for any future custom 2.0 extensions.