### PR TITLE
Protect the version check from yaml, use extension version on startup

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "1.1.14"
+__version__ = "1.1.15"

--- a/dynatrace_extension/cli/create/extension_template/setup.py.template
+++ b/dynatrace_extension/cli/create/extension_template/setup.py.template
@@ -3,13 +3,16 @@ from setuptools import setup, find_packages
 
 
 def find_version() -> str:
+    version = "0.0.1"
     extension_yaml_path = Path(__file__).parent / "extension" / "extension.yaml"
-    version = "0.0.0"
-    with open(extension_yaml_path) as f:
-        for l in f.readlines():
-            if l.startswith("version"):
-                version = l.split(" ")[-1].strip("\"")
-                break
+    try:
+        with open(extension_yaml_path, encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("version"):
+                    version = line.split(" ")[-1].strip("\"")
+                    break
+    except Exception:
+        pass
     return version
 
 

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -8,8 +8,8 @@ import signal
 import sys
 import threading
 import time
-from collections import deque
 from argparse import ArgumentParser
+from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from enum import Enum
@@ -1015,9 +1015,8 @@ class Extension:
         self._client.send_dt_event(event)
 
     def get_version(self) -> str:
-        """Return the version of extensions sdk library."""
-
-        return __version__
+        """Return the extension version."""
+        return self.activation_config.version
 
     @property
     def techrule(self) -> str:


### PR DESCRIPTION
This makes two changes:

1. Puts the `setup.py` logic that parses `extension.yaml ` in a try catch, to make it work nice with tools that attempt to parse setup.py but are not `pip`, like `snyk`
2. Uses the version from `activation.json` or the `activation config` to print the log message when starting the extension