### PR TITLE
Fix event batch logic

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "1.1.18"
+__version__ = "1.1.19"

--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "1.1.19"
+__version__ = "1.1.20"

--- a/dynatrace_extension/sdk/communication.py
+++ b/dynatrace_extension/sdk/communication.py
@@ -430,9 +430,12 @@ class DebugClient(CommunicationClient):
                 responses.append(response)
         return responses
 
-    def send_events(self, events: dict | list[dict], eec_enrichment: bool = True) -> dict | None:
-        self.logger.info(f"send_events (enrichment = {eec_enrichment}): {events}")
-        return None
+    def send_events(self, events: dict | list[dict], eec_enrichment: bool = True) -> list[dict | None]:
+        self.logger.info(f"send_events (enrichment = {eec_enrichment}): {len(events)} events")
+        if self.print_metrics:
+            for event in events:
+                self.logger.info(f"sendf_event: {event}")
+        return []
 
     def send_sfm_metrics(self, mint_lines: list[str]) -> MintResponse:
         for line in mint_lines:

--- a/dynatrace_extension/sdk/communication.py
+++ b/dynatrace_extension/sdk/communication.py
@@ -24,7 +24,7 @@ CONTENT_TYPE_PLAIN = "text/plain;charset=utf-8"
 COUNT_METRIC_ITEMS_DICT = TypeVar("COUNT_METRIC_ITEMS_DICT", str, List[str])
 MAX_MINT_LINES_PER_REQUEST = 1000
 MAX_LOG_EVENTS_PER_REQUEST = 50_000
-MAX_LOG_REQUEST_SIZE = 5_000_000
+MAX_LOG_REQUEST_SIZE = 5_000_000  # 5_242_880
 HTTP_BAD_REQUEST = 400
 
 
@@ -487,7 +487,7 @@ def divide_logs_into_batches(logs: list[dict]):
         events_left -= 1
 
         if event is not None:
-            event_size = len(event)
+            event_size = len(f"{event}".encode())
 
             if batch_size + event_size >= MAX_LOG_REQUEST_SIZE:
                 yield batch

--- a/tests/sdk/test_communication.py
+++ b/tests/sdk/test_communication.py
@@ -1,23 +1,10 @@
 import unittest
 from unittest.mock import MagicMock, mock_open, patch
 
-from dynatrace_extension.sdk.communication import HttpClient, divide_into_chunks
+from dynatrace_extension.sdk.communication import MAX_LOG_REQUEST_SIZE, MAX_METRIC_REQUEST_SIZE, HttpClient, divide_into_batches
 
 
 class TestCommunication(unittest.TestCase):
-    def test_large_chunk(self):
-        large_list = ["metric 1"] * 1400
-        chunks = list(divide_into_chunks(large_list, 1000))
-        self.assertEqual(len(chunks), 2)
-        self.assertEqual(len(chunks[0]), 1000)
-        self.assertEqual(len(chunks[1]), 400)
-
-    def test_small_chunk(self):
-        small_list = ["metric 1"] * 10
-        chunks = list(divide_into_chunks(small_list, 1000))
-        self.assertEqual(len(chunks), 1)
-        self.assertEqual(len(chunks[0]), 10)
-
     @patch("builtins.open", mock_open(read_data="test_token"))
     @patch.object(HttpClient, "_make_request", return_value=MagicMock())
     def test_http_client_metric_report(self, mock_make_request):
@@ -26,10 +13,63 @@ class TestCommunication(unittest.TestCase):
         responses = http_client.send_metrics(few_metrics)
         self.assertEqual(len(responses), 1)
 
-        many_metrics = ["metric 1"] * 1400
+        many_metrics = ['my.metric,dim="dim" 10'] * 500 * 100
         responses = http_client.send_metrics(many_metrics)
         self.assertEqual(len(responses), 2)
 
         no_metrics = []
         responses = http_client.send_metrics(no_metrics)
         self.assertEqual(len(responses), 0)
+
+    def test_large_log_chunk(self):
+
+        # This is 14_660_000 bytes
+        events = []
+        for i in range(5000):
+            attributes = {}
+            for j in range(150):
+                attributes[f"attribute{j}"] = j
+            events.append(attributes)
+
+        # it needs to be divided into 4 lists, each with 3_665_000 bytes
+        chunks = list(divide_into_batches(events, MAX_LOG_REQUEST_SIZE))
+        self.assertEqual(len(chunks), 4)
+        self.assertEqual(len(chunks[0]), 3665000)
+        self.assertEqual(len(chunks[1]), 3665000)
+        self.assertEqual(len(chunks[2]), 3665000)
+        self.assertEqual(len(chunks[3]), 3665000)
+
+    def test_small_log_chunk(self):
+        events = []
+        for i in range(10):
+            attributes = {}
+            for j in range(10):
+                attributes[f"attribute{j}"] = j
+            events.append(attributes)
+
+        chunks = list(divide_into_batches(events, MAX_LOG_REQUEST_SIZE))
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(len(chunks[0]), 1720)
+
+    def test_large_metric_chunk(self):
+
+        metrics = ['my.metric,dim="dim" 10'] * 500 * 100  # 1_300_000 bytes, but becomes 1_149_999 with the newlines
+
+        # it needs to be divided into 2 lists, each with 650_000 bytes
+        chunks = list(divide_into_batches(metrics, MAX_METRIC_REQUEST_SIZE, "\n"))
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(len(chunks[0]), 574999)
+        self.assertEqual(len(chunks[1]), 575000)
+
+    def test_small_metric_chunk(self):
+        metrics = ['my.metric,dim="dim" 10'] * 100
+
+        chunks = list(divide_into_batches(metrics, MAX_METRIC_REQUEST_SIZE, "\n"))
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(len(chunks[0]), 2299)
+
+    def test_no_metrics(self):
+        metrics = []
+
+        chunks = list(divide_into_batches(metrics, MAX_METRIC_REQUEST_SIZE, "\n"))
+        self.assertEqual(len(chunks), 0)


### PR DESCRIPTION
The previous method was checking the "len" of the dictionary, which doesn't make sense, because that only counts the number of keys in a dictionary, it doesn't check bytes.

Rewrite to be more generic, and make metrics and logs use the same method.