### PR TITLE
#69 - Fix an issue with the callback iteration timestamp drifting

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -45,6 +45,7 @@ class WrappedCallback:
         self.ok_count = 0  # counter per interval = 1 min by default
         self.timeouts_count = 0  # counter per interval = 1 min by default
         self.exception_count = 0  # counter per interval = 1 min by default
+        self.iterations = 0 # how many times we ran the callback iterator for this callback
 
     def get_current_time_with_cluster_diff(self):
         return datetime.now() + timedelta(milliseconds=self.cluster_time_diff)
@@ -56,7 +57,6 @@ class WrappedCallback:
         self.running = True
         self.executions_total += 1
         self.executions_per_interval += 1
-        self.next_run = datetime.now() + self.interval
         start_time = timer()
         failed = False
         try:
@@ -133,3 +133,12 @@ class WrappedCallback:
         self.duration_interval_total = 0
         self.exception_count = 0
         self.executions_per_interval = 0
+
+    def get_next_execution_timestamp(self) -> float:
+        """
+        Get the timestamp for the next execution of the callback
+        This is done using execution total, the interval and the start timestamp
+        :return: datetime
+        """
+        return (self.start_timestamp + timedelta(seconds=self.interval.total_seconds() * (self.iterations or 1))).timestamp()
+

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -789,7 +789,9 @@ class Extension:
 
     def _callback_iteration(self, callback: WrappedCallback):
         self._callbacks_executor.submit(self._run_callback, callback)
-        self._scheduler.enter(callback.interval.total_seconds(), 1, self._callback_iteration, (callback,))
+        callback.iterations += 1
+        next_timestamp = callback.get_next_execution_timestamp()
+        self._scheduler.enterabs(next_timestamp, 1, self._callback_iteration, (callback,))
 
     def _start_extension_loop(self):
         api_logger.debug(f"Starting main loop for monitoring configuration: '{self.monitoring_config_name}'")


### PR DESCRIPTION
The callback iteration slowly drifts a few milliseconds per call This is due to inaccuracies of time.sleep and some overhead on the `_run_callback` method

This fix the issue by using sched.enterabs instead of sched.enter. This time to enter is always calculated based on the start timestamp of the callback

There will still be some milliseconds variation from execution to execution, but it will never drift.