### PR TITLE
Changest to heartbeat iteration

### DIFF
--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -25,7 +25,7 @@ from .metric import Metric, MetricType, SfmMetric, SummaryStat
 from .runtime import RuntimeProperties
 from .snapshot import Snapshot
 
-HEARTBEAT_INTERVAL = timedelta(seconds=30)
+HEARTBEAT_INTERVAL = timedelta(seconds=60)
 METRIC_SENDING_INTERVAL = timedelta(seconds=30)
 SFM_METRIC_SENDING_INTERVAL = timedelta(seconds=60)
 TIME_DIFF_INTERVAL = timedelta(seconds=60)
@@ -953,7 +953,6 @@ class Extension:
                 return overall_status
 
         for callback in self._scheduled_callbacks:
-            overall_status.timestamp = int(callback.get_adjusted_metric_timestamp().timestamp() * 1000)
             if callback.status.is_error():
                 overall_status.status = callback.status.status
                 messages.append(f"{callback}: {callback.status.message}")


### PR DESCRIPTION
Proposing 2 changes to the current heartbeat iteration implementation.

## 1. Heartbeat interval

The EEC exposes the `/alive` endpoint for heartbeats and statuses sent by the datasource. Internal [doc](https://dt-rnd.atlassian.net/wiki/spaces/IM/pages/37519761/EEC+and+DS+status+reporting#EECandDSstatusreporting-/aliveendpointforDSstatusreporting) mentions that statuses shouldn't be sent more than every 1 minute. In addition - if sent more frequently - EEC collects all statuses and only sends the last received one.

Based on this, we should compose & send the SDK execution status **every 60 sec** instead of current 30.

## 2. Status timestamp

For some reason every time the `heartbeat` loops through user-defined callbacks it also ends up [manually adjusting](https://github.com/dynatrace-extensions/dt-extensions-python-sdk/blob/main/dynatrace_extension/sdk/extension.py#L956) the status timestamp to the adjusted metric timestamp of the last callback in the array.

While this may not break things it certainly doesn't make any sense -> we run every 1 minute, compose an aggregated status, and should share it at **current point in time**.