### PR TITLE
Small changes to the template

### DIFF
--- a/dynatrace_extension/cli/create/extension_template/extension_name/__main__.py.template
+++ b/dynatrace_extension/cli/create/extension_template/extension_name/__main__.py.template
@@ -5,6 +5,9 @@ class ExtensionImpl(Extension):
 
     def initialize(self):
         self.extension_name = "%extension_name%"
+        self.extension_version = self.activation_config.version
+        self.logger.name = self.extension_name
+        self.logger.info(f"Initializing {self.extension_name} {self.extension_version}")
 
     def query(self):
         """

--- a/dynatrace_extension/cli/create/extension_template/extension_name/__main__.py.template
+++ b/dynatrace_extension/cli/create/extension_template/extension_name/__main__.py.template
@@ -3,12 +3,6 @@ from dynatrace_extension import Extension, Status, StatusValue
 
 class ExtensionImpl(Extension):
 
-    def initialize(self):
-        self.extension_name = "%extension_name%"
-        self.extension_version = self.activation_config.version
-        self.logger.name = self.extension_name
-        self.logger.info(f"Initializing {self.extension_name} {self.extension_version}")
-
     def query(self):
         """
         The query method is automatically scheduled to run every minute
@@ -38,7 +32,7 @@ class ExtensionImpl(Extension):
 
 
 def main():
-    ExtensionImpl().run()
+    ExtensionImpl(name="%extension_name%").run()
 
 
 

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -156,19 +156,20 @@ class Extension:
             Extension._instance = super(__class__, cls).__new__(cls)
         return Extension._instance
 
-    def __init__(self) -> None:
+    def __init__(self, name: str) -> None:
         # do not initialize already created singleton
         if hasattr(self, "logger"):
             return
 
         self.logger = extension_logger
+        self.logger.name = name
 
         self.extension_config: str = ""
         self._feature_sets: dict[str, list[str]] = {}
 
         # Useful metadata, populated once the extension is started
-        self.extension_name = ""  # Needs to be set by the developer if they so decide
-        self.extension_version = ""
+        self.extension_name = name
+        self.extension_version = self.get_version()
         self.monitoring_config_name = ""
         self._task_id = "development_task_id"
         self._monitoring_config_id = "development_config_id"

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -156,7 +156,7 @@ class Extension:
             Extension._instance = super(__class__, cls).__new__(cls)
         return Extension._instance
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str = "") -> None:
         # do not initialize already created singleton
         if hasattr(self, "logger"):
             return

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -242,6 +242,8 @@ class Extension:
         starting_message = f"Starting {self}"
         api_logger.info("-" * len(starting_message))
         api_logger.info(starting_message)
+        api_logger.info("-" * len(starting_message))
+
 
     def __repr__(self):
         return f"{self.__class__.__name__}(name={self.extension_name}, version={self.extension_version})"

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -169,7 +169,7 @@ class Extension:
 
         # Useful metadata, populated once the extension is started
         self.extension_name = name
-        self.extension_version = self.get_version()
+        self.extension_version = ""
         self.monitoring_config_name = ""
         self._task_id = "development_task_id"
         self._monitoring_config_id = "development_config_id"
@@ -239,8 +239,12 @@ class Extension:
                 params = params + args
             self.schedule(function, interval, params, activation_type)
 
-        api_logger.info("-----------------------------------------------------")
-        api_logger.info(f"Starting {self.__class__} {self.extension_name}, version: {self.get_version()}")
+        starting_message = f"Starting {self}"
+        api_logger.info("-" * len(starting_message))
+        api_logger.info(starting_message)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(name={self.extension_name}, version={self.extension_version})"
 
     @property
     def is_helper(self) -> bool:


### PR DESCRIPTION
Proposing a couple of changes I find myself adding to every extension.

Namely, change the `initialize` function from:

```python
    def initialize(self):
        self.extension_name = "%extension_name%"
```

to 

```python
    def initialize(self):
        self.extension_name = "%extension_name%"
        self.extension_version = self.activation_config.version
        self.logger.name = self.extension_name
        self.logger.info(f"Initializing {self.extension_name} {self.extension_version}")
```

---

Changes:
1. Set the extension version based on activation config version
2. Set the logger name to the extension name (often `dynatrace_extension.sdk.extension` is longer and less relevant than the extension name)
3. Log by default the extension along with its version. This helps in troubleshooting and is more relevant than the SDK version which is currently logged instead.