### PR TITLE
updated setup.py to resolve metadata from project (round 2)

### DIFF
--- a/dynatrace_extension/cli/create/extension_template/setup.py.template
+++ b/dynatrace_extension/cli/create/extension_template/setup.py.template
@@ -16,10 +16,10 @@ class ExtensionMetadata():
         Initialize our internal data structures accordingly.
         '''
 
-        self._activation = self.__read_activation()
-        self._extension = self.__read_extension()
+        self._activation = self._read_activation()
+        self._extension = self._read_extension()
 
-    def __read_activation(self):
+    def _read_activation(self):
         '''
         Load the metadata for this extension from the activationSchema.json
         file. If a failure occurs (i.e. no file), initialize with an empty
@@ -31,12 +31,12 @@ class ExtensionMetadata():
 
         try:
             with open(Path(__file__).parent / "extension" / "activationSchema.json",
-                      mode='r', encoding="utf-8") as fActivationSchema:
-                return json.load(fActivationSchema)
+                      mode='r', encoding="utf-8") as f_activation_schema:
+                return json.load(f_activation_schema)
         except Exception:
             return {}
 
-    def __read_extension(self):
+    def _read_extension(self):
         '''
         Load the metadata for this extension from the extension.yaml file
         If a failure occurs (i.e. no file), initialize with an empty dict
@@ -54,13 +54,13 @@ class ExtensionMetadata():
             # the config dict.
 
             with open(Path(__file__).parent / "extension" / "extension.yaml",
-                        mode='r', encoding="utf-8") as fExtension:
+                        mode='r', encoding="utf-8") as f_extension_yaml:
                 
                 # We are using key to keep track of where we are in the
                 # yaml document.
 
                 key = ''
-                for line in fExtension:
+                for line in f_extension_yaml:
 
                     # skip blank lines...
 

--- a/dynatrace_extension/cli/create/extension_template/setup.py.template
+++ b/dynatrace_extension/cli/create/extension_template/setup.py.template
@@ -1,27 +1,196 @@
+import json
 from pathlib import Path
+import re
 from setuptools import setup, find_packages
 
 
-def find_version() -> str:
-    version = "0.0.1"
-    extension_yaml_path = Path(__file__).parent / "extension" / "extension.yaml"
-    try:
-        with open(extension_yaml_path, encoding="utf-8") as f:
-            for line in f:
-                if line.startswith("version"):
-                    version = line.split(" ")[-1].strip("\"")
-                    break
-    except Exception:
-        pass
-    return version
+class ExtensionMetadata():
+    '''
+    Collects and makes available all extension metadata available to populate
+    the setup() command when building the extension.
+    '''
 
+    def __init__(self):
+        '''
+        Initialize our internal data structures accordingly.
+        '''
 
-setup(name="%extension_name%",
-      version=find_version(),
-      description="%Extension_Name% python EF2 extension",
-      author="Dynatrace",
+        self._activation = self.__read_activation()
+        self._extension = self.__read_extension()
+
+    def __read_activation(self):
+        '''
+        Load the metadata for this extension from the activationSchema.json
+        file. If a failure occurs (i.e. no file), initialize with an empty
+        dict so that subsequent calls just return the default instead.
+
+        Returns:
+            dict containing configuration from schemaActivation.json.
+        '''
+
+        try:
+            with open(Path(__file__).parent / "extension" / "activationSchema.json",
+                      mode='r', encoding="utf-8") as fActivationSchema:
+                return json.load(fActivationSchema)
+        except Exception:
+            return {}
+
+    def __read_extension(self):
+        '''
+        Load the metadata for this extension from the extension.yaml file
+        If a failure occurs (i.e. no file), initialize with an empty dict
+        so that subsequent calls just return the default instead.
+
+        Returns:
+            dict containing configuration from extension.yaml
+        '''
+
+        config = {}
+        try:
+
+            # Process each line individually looking for keywords we are
+            # interested it. If we find a value we care about, add it to
+            # the config dict.
+
+            with open(Path(__file__).parent / "extension" / "extension.yaml",
+                        mode='r', encoding="utf-8") as fActivationSchema:
+                
+                # We are using key to keep track of where we are in the
+                # yaml document.
+
+                key = ''
+                for line in fActivationSchema:
+
+                    # skip blank lines...
+
+                    if line.strip() == '':
+                        continue
+
+                    # if the line starts with a character, it is a root level
+                    # item.
+
+                    elif re.match('^[a-zA-Z]', line):
+
+                        # set the key to the root level item's key name. then
+                        # process any root level items with values we need to
+                        # provide.
+
+                        key = line.split(':', 2)[0].strip()
+
+                        if key == 'version':
+                            config['version'] = line.split(':')[-1].strip().replace('"', '')
+
+                    else:
+
+                        # since our configurations could be multiple levels
+                        # deep, we need to handle both tracking and value
+                        # entries...
+
+                        # under 'author', we need the value of 'name'.
+
+                        if key == 'author' and re.match('^\s+name\:', line):
+                            config['author.name'] = line.split(':')[-1].strip().replace('"', '')
+                            continue
+
+                        # for 'python', we need the value stored at key
+                        # 'python.runtime.version.min'. to do this, we need to
+                        # work our way down, updating the key as we go. once
+                        # we make it to 'python.runtime.version', we can check
+                        # for 'min' with a value and grab it.
+
+                        if key == 'python' and re.match('^\s+runtime\:', line):
+                            key = 'python.runtime'
+
+                        elif key == 'python.runtime' and re.match('^\s+version\:', line):
+                            key = 'python.runtime.version'
+
+                        elif key == 'python.runtime.version' and re.match('^\s+min\:', line):
+                            config['python.runtime.version.min'] = line.split(':')[-1].strip().replace('"', '')
+
+        except Exception:
+            config = {}
+        
+        return config
+
+    @property
+    def author(self) -> str:
+        '''
+        Returns the author name as configured by the 'author.name' value
+        within the extension.yaml file.
+
+        Returns:
+            the author name of the extension. if none is configured, the
+            value 'dynatrace' is returned.
+        '''
+
+        return self._extension.get('author.name', 'dynatrace')
+
+    @property
+    def display_name(self) -> str:
+        '''
+        Returns the display name as configured by the 'displayName'
+        value within the activationSchema.json file.
+
+        Returns:
+            the display name of the extension. if none is configured, the
+            value '%extension_name%' is returned.
+        '''
+
+        return self._activation.get('displayName', '%extension_name%')
+
+    @property
+    def long_description(self) -> str:
+        '''
+        Returns the long description as configured by the 'description'
+        value within the activationSchema.json file.
+
+        Returns:
+            the description of the extension. if none is configured, the
+            value '%extension_name%' is returned.
+        '''
+
+        return self._activation.get('description', '%extension_name%')
+
+    @property
+    def python_min_version(self) -> str:
+        '''
+        Returns the minimum python version as configured by the
+        'python.runtime.version.min' setting within the extension.yaml.
+
+        Returns:
+            the minimum python version supported by the extension. if none is
+            configured, '3.10' is returned.
+        '''
+
+        return self._extension.get('python.runtime.version.min', '3.10')
+
+    @property
+    def version(self) -> str:
+        '''
+        Returns the extension version as configured by the 'version' setting
+        within the extension.yaml.
+
+        Returns:
+            the current version of this extension. if none is configured, the
+            value '0.0.1' is returned.
+        '''
+
+        return self._extension.get('version', '0.0.1')
+
+#
+# Setup
+#
+
+# Read in available extension metadata from the project file(s).
+ext_meta = ExtensionMetadata()
+
+setup(name="ftb_fi1770",
+      version=ext_meta.version,
+      description=ext_meta.display_name,
+      long_description=ext_meta.long_description,
+      author=ext_meta.author,
       packages=find_packages(),
-      python_requires=">=3.10",
+      python_requires=f">={ext_meta.python_min_version}",
       include_package_data=True,
       install_requires=["dt-extensions-sdk"],
       extras_require={"dev": ["dt-extensions-sdk[cli]"]},

--- a/dynatrace_extension/cli/create/extension_template/setup.py.template
+++ b/dynatrace_extension/cli/create/extension_template/setup.py.template
@@ -53,13 +53,13 @@ class ExtensionMetadata():
             # the config dict.
 
             with open(Path(__file__).parent / "extension" / "extension.yaml",
-                        mode='r', encoding="utf-8") as fActivationSchema:
+                        mode='r', encoding="utf-8") as fExtension:
                 
                 # We are using key to keep track of where we are in the
                 # yaml document.
 
                 key = ''
-                for line in fActivationSchema:
+                for line in fExtension:
 
                     # skip blank lines...
 

--- a/dynatrace_extension/cli/create/extension_template/setup.py.template
+++ b/dynatrace_extension/cli/create/extension_template/setup.py.template
@@ -3,6 +3,7 @@ from pathlib import Path
 import re
 from setuptools import setup, find_packages
 
+EXTENSION_NAME = '%extension_name%'
 
 class ExtensionMetadata():
     '''
@@ -133,10 +134,10 @@ class ExtensionMetadata():
 
         Returns:
             the display name of the extension. if none is configured, the
-            value '%extension_name%' is returned.
+            value of EXTENSION_NAME is returned.
         '''
 
-        return self._activation.get('displayName', '%extension_name%')
+        return self._activation.get('displayName', EXTENSION_NAME)
 
     @property
     def long_description(self) -> str:
@@ -146,10 +147,10 @@ class ExtensionMetadata():
 
         Returns:
             the description of the extension. if none is configured, the
-            value '%extension_name%' is returned.
+            value of EXTENSION_NAME is returned.
         '''
 
-        return self._activation.get('description', '%extension_name%')
+        return self._activation.get('description', EXTENSION_NAME)
 
     @property
     def python_min_version(self) -> str:
@@ -184,7 +185,7 @@ class ExtensionMetadata():
 # Read in available extension metadata from the project file(s).
 ext_meta = ExtensionMetadata()
 
-setup(name="ftb_fi1770",
+setup(EXTENSION_NAME,
       version=ext_meta.version,
       description=ext_meta.display_name,
       long_description=ext_meta.long_description,


### PR DESCRIPTION
Same update taking into account the feedback from the previous submission.  This version parses the associated metadata from the existing extension.yaml/activationSchema.json files so that developers don't have to maintain those values in multiple locations.

It now
- will not fail if extenison.yaml/activationSchema.json are missing (will just return default values instead).
- does not add a dependency on PyYAML.

Thank you!