### PR TITLE
Fix time drifting when scheduling internal callbacks

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "1.2.8"
+__version__ = "1.2.9"

--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"


### PR DESCRIPTION
Fixes constant time drifting by a few milliseconds on each scheduled internal callback executions.

Previous behavior:
```
Line   6: 2024-07-25 09:32:17,776 [INFO] api (ThreadPoolExecutor-1_0): send_status: '{"status": "OK", "message": ""}'
Line  12: 2024-07-25 09:33:17,793 [INFO] api (ThreadPoolExecutor-1_0): send_status: '{"status": "OK", "message": ""}'
Line  24: 2024-07-25 09:34:17,795 [INFO] api (ThreadPoolExecutor-1_0): send_status: '{"status": "OK", "message": ""}'
Line  36: 2024-07-25 09:35:17,809 [INFO] api (ThreadPoolExecutor-1_0): send_status: '{"status": "OK", "message": ""}'
Line  49: 2024-07-25 09:36:17,818 [INFO] api (ThreadPoolExecutor-1_2): send_status: '{"status": "OK", "message": ""}'
Line  61: 2024-07-25 09:37:17,827 [INFO] api (ThreadPoolExecutor-1_1): send_status: '{"status": "OK", "message": ""}'
Line  73: 2024-07-25 09:38:17,832 [INFO] api (ThreadPoolExecutor-1_2): send_status: '{"status": "OK", "message": ""}'
Line  84: 2024-07-25 09:39:17,840 [INFO] api (ThreadPoolExecutor-1_2): send_status: '{"status": "OK", "message": ""}'
Line  96: 2024-07-25 09:40:17,843 [INFO] api (ThreadPoolExecutor-1_1): send_status: '{"status": "OK", "message": ""}'
Line 109: 2024-07-25 09:41:17,851 [INFO] api (ThreadPoolExecutor-1_1): send_status: '{"status": "OK", "message": ""}'
Line 120: 2024-07-25 09:42:17,858 [INFO] api (ThreadPoolExecutor-1_1): send_status: '{"status": "OK", "message": ""}'
Line 132: 2024-07-25 09:43:17,870 [INFO] api (ThreadPoolExecutor-1_2): send_status: '{"status": "OK", "message": ""}'
Line 145: 2024-07-25 09:44:17,886 [INFO] api (ThreadPoolExecutor-1_2): send_status: '{"status": "OK", "message": ""}'
Line 156: 2024-07-25 09:45:17,891 [INFO] api (ThreadPoolExecutor-1_1): send_status: '{"status": "OK", "message": ""}'
Line 168: 2024-07-25 09:46:17,894 [INFO] api (ThreadPoolExecutor-1_0): send_status: '{"status": "OK", "message": ""}'
Line 180: 2024-07-25 09:47:17,909 [INFO] api (ThreadPoolExecutor-1_2): send_status: '{"status": "OK", "message": ""}'
Line 192: 2024-07-25 09:48:17,918 [INFO] api (ThreadPoolExecutor-1_1): send_status: '{"status": "OK", "message": ""}'
```

New behavior:
```
Line   5: 2024-07-25 12:01:28,931 [INFO] api (ThreadPoolExecutor-1_0): send_status: '{"status": "OK", "message": ""}'
Line  17: 2024-07-25 12:02:28,918 [INFO] api (ThreadPoolExecutor-1_0): send_status: '{"status": "OK", "message": ""}'
Line  28: 2024-07-25 12:03:28,924 [INFO] api (ThreadPoolExecutor-1_1): send_status: '{"status": "OK", "message": ""}'
Line  39: 2024-07-25 12:04:28,912 [INFO] api (ThreadPoolExecutor-1_1): send_status: '{"status": "OK", "message": ""}'
Line  44: 2024-07-25 12:05:28,919 [INFO] api (ThreadPoolExecutor-1_2): send_status: '{"status": "OK", "message": ""}'
Line  61: 2024-07-25 12:06:28,923 [INFO] api (ThreadPoolExecutor-1_2): send_status: '{"status": "OK", "message": ""}'
Line  72: 2024-07-25 12:07:28,917 [INFO] api (ThreadPoolExecutor-1_3): send_status: '{"status": "OK", "message": ""}'
Line  77: 2024-07-25 12:08:28,921 [INFO] api (ThreadPoolExecutor-1_0): send_status: '{"status": "OK", "message": ""}'
Line  94: 2024-07-25 12:09:28,910 [INFO] api (ThreadPoolExecutor-1_1): send_status: '{"status": "OK", "message": ""}'
Line 100: 2024-07-25 12:10:28,908 [INFO] api (ThreadPoolExecutor-1_1): send_status: '{"status": "OK", "message": ""}'
Line 116: 2024-07-25 12:11:28,909 [INFO] api (ThreadPoolExecutor-1_2): send_status: '{"status": "OK", "message": ""}'
Line 126: 2024-07-25 12:12:28,921 [INFO] api (ThreadPoolExecutor-1_0): send_status: '{"status": "OK", "message": ""}'
Line 138: 2024-07-25 12:13:28,908 [INFO] api (ThreadPoolExecutor-1_3): send_status: '{"status": "OK", "message": ""}'
Line 149: 2024-07-25 12:14:28,911 [INFO] api (ThreadPoolExecutor-1_1): send_status: '{"status": "OK", "message": ""}'
Line 160: 2024-07-25 12:15:28,910 [INFO] api (ThreadPoolExecutor-1_0): send_status: '{"status": "OK", "message": ""}'
Line 171: 2024-07-25 12:16:28,923 [INFO] api (ThreadPoolExecutor-1_3): send_status: '{"status": "OK", "message": ""}'
Line 182: 2024-07-25 12:17:28,917 [INFO] api (ThreadPoolExecutor-1_3): send_status: '{"status": "OK", "message": ""}'
```