### PR TITLE
Change heartbeat interval from 60s to 50s

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "1.2.9"
+__version__ = "1.2.10"

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -25,7 +25,7 @@ from .metric import Metric, MetricType, SfmMetric, SummaryStat
 from .runtime import RuntimeProperties
 from .snapshot import Snapshot
 
-HEARTBEAT_INTERVAL = timedelta(seconds=60)
+HEARTBEAT_INTERVAL = timedelta(seconds=50)
 METRIC_SENDING_INTERVAL = timedelta(seconds=30)
 SFM_METRIC_SENDING_INTERVAL = timedelta(seconds=60)
 TIME_DIFF_INTERVAL = timedelta(seconds=60)


### PR DESCRIPTION
Even without timedrift, the extension restart issue could still replicate, due to lack of "safety buffer"

Example:

```
{
	"configId":"4b4660ab-426f-370c-b206-f440a28ecdec","taskId":"2728623243455997848","PID":"N/A",
	"executionStatuses":[{"status":"OK","message":"OK","timestamp":"2024-07-30 07:37:51.739 UTC"}],
	"processStatuses":[
					{"status":"STARTUP_SCHEDULED","message":"Datasource startup in 0 minutes","timestamp":"2024-07-30 07:38:12.821 UTC"}, 
					{"status":"TIMED_OUT_RESTART","message":"No keepalive from datasource python. Restarting","timestamp":"2024-07-30 07:37:51.738 UTC"}
					]
}
```

In the example above, the heartbeat was received at `07:37:51.739`, but EEC scheduled restart at `07:37:51.738`