### PR TITLE
Do not run heartbeats during fastchecks

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "1.2.10"
+__version__ = "1.2.11"

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -984,6 +984,8 @@ class Extension:
             callback.cluster_time_diff = self._cluster_time_diff
 
     def _heartbeat(self):
+        if self._is_fastcheck:
+            return
         response = bytes("not set", "utf-8")
         try:
             overall_status = self._build_current_status()


### PR DESCRIPTION
During fastchecks heartbeats will fail, so we should not run them