### PR TITLE
Restrict scheduling seconds

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "1.2.10"
+__version__ = "1.2.11"

--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "1.2.11"
+__version__ = "1.2.12"

--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -89,13 +89,13 @@ class WrappedCallback:
     def initial_wait_time(self) -> float:
         if not self.running_in_sim:
             """
-            Here we chose a random second between 1 and 59 to start the callback
+            Here we chose a random second between 5 and 55 to start the callback
             This is to distribute load for extension running on this host
             When running from the simulator, this is not done
             """
 
             now = self.get_current_time_with_cluster_diff()
-            random_second = random.randint(1, 59)  # noqa: S311
+            random_second = random.randint(5, 55)  # noqa: S311
             next_execution = datetime.now().replace(second=random_second, microsecond=0)
             if next_execution <= now:
                 # The random chosen second already passed this minute

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -984,6 +984,8 @@ class Extension:
             callback.cluster_time_diff = self._cluster_time_diff
 
     def _heartbeat(self):
+        if self._is_fastcheck:
+            return
         response = bytes("not set", "utf-8")
         try:
             overall_status = self._build_current_status()


### PR DESCRIPTION
Stop scheduling at very early times to avoid double executions on the same minute

Instead of chosing from 1-59 as the second to start, we chose from 5 to 55