### PR TITLE
add default log location for snapshot

### DIFF
--- a/dynatrace_extension/sdk/snapshot.py
+++ b/dynatrace_extension/sdk/snapshot.py
@@ -193,6 +193,8 @@ def find_log_dir() -> Path:
         for line in f:
             if line.startswith("LogDir"):
                 log_dir = line.split("=")[1].strip()
+                if not log_dir:
+                    return Path(os.path.expandvars("%PROGRAMDATA%") + "/dynatrace/oneagent/log") if os.name == "nt" else Path("/var/log/dynatrace/oneagent")
                 return Path(log_dir)
     msg = f"Could not find LogDir in {installation_conf}"
     raise Exception(msg)


### PR DESCRIPTION
Sometimes, the **LogDir** field will be empty, so we assume the default location for these cases.