### PR TITLE
#89 - Start the keepalive thread sooner

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.2.13"
+__version__ = "1.2.14"

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -748,6 +748,7 @@ class Extension:
 
         if not self._is_fastcheck:
             try:
+                self._heartbeat_iteration()
                 self.initialize()
                 if not self.is_helper:
                     self.schedule(self.query, timedelta(minutes=1))
@@ -813,7 +814,6 @@ class Extension:
         # These were scheduled before the extension started, schedule them now
         for callback in self._scheduled_callbacks_before_run:
             self._schedule_callback(callback)
-        self._heartbeat_iteration()
         self._metrics_iteration()
         self._sfm_metrics_iteration()
         self._timediff_iteration()


### PR DESCRIPTION
We need to start this as soon as possible because the initialize might take a long time and the EEC needs to receive keep alives as the initialize method is running