### PR TITLE
Seperate ThreadPoolExecutor for heartbeat

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.4.0"
+__version__ = "1.3.1"

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -32,6 +32,7 @@ TIME_DIFF_INTERVAL = timedelta(seconds=60)
 
 CALLBACKS_THREAD_POOL_SIZE = 100
 INTERNAL_THREAD_POOL_SIZE = 20
+HEARTBEAT_THREAD_POOL_SIZE = 10
 
 RFC_3339_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 DATASOURCE_TYPE = "python"
@@ -220,6 +221,7 @@ class Extension:
         # Executors for the callbacks and internal methods
         self._callbacks_executor = ThreadPoolExecutor(max_workers=CALLBACKS_THREAD_POOL_SIZE)
         self._internal_executor = ThreadPoolExecutor(max_workers=INTERNAL_THREAD_POOL_SIZE)
+        self._heartbeat_executor = ThreadPoolExecutor(max_workers=HEARTBEAT_THREAD_POOL_SIZE)
 
         # Extension metrics
         self._metrics_lock = RLock()
@@ -827,7 +829,7 @@ class Extension:
         self._scheduler.enterabs(next_timestamp, 1, self._timediff_iteration)
 
     def _heartbeat_iteration(self):
-        self._internal_executor.submit(self._heartbeat)
+        self._heartbeat_executor.submit(self._heartbeat)
         next_timestamp = self._get_and_set_next_internal_callback_timestamp("heartbeat", HEARTBEAT_INTERVAL)
         self._scheduler.enterabs(next_timestamp, 2, self._heartbeat_iteration)
 


### PR DESCRIPTION
Currently a single ThreadPoolExecutor takes care of callbacks sending metrics, logs, checking time diff and sending hearbeat.
Knowning that log parsing takes some time on EEC side, when there are many log requests in as single interval (when using `report_log_event()` 1 request is created for each single log, due to that it's possible for tens or hundreds of requests in each interval), the heartbeat might not be send on time and EEC could restart the process.

This PR adds a seperate ThreadPoolExecutor for solely heartbeat purpose, making it independent from other functionalities.