### PR TITLE
Batch logs before sending

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"


### PR DESCRIPTION
Currently report_event() and report_log_event() methods in PythonSDK schedule each log to be send in a separate request to EEC.
This causes problems due to EEC’s insufficient log ingest performance → 200-300ms request response time on average, which can cause significant problems when there are hundreds and thousands of requests in a single interval.

To minimize the impact of the subpar efficiency, the goal is to batch reported logs and send them in a single message once per interval.
Similar mechanism is currently implemented for metrics ingest.

What is important is that the change must not change the interface, so that no changes are required for all built-in and custom Python extensions.

What could be worth implementing however, is an optional parameter which would give the possibility to also send logs in the “old way”. This could be useful for performance testing in the future and in this case logs should arrive earlier on the server, hence it could be useful in a production environment.