### PR TITLE
Default to `timezone.utc` for `datetime.now()` calls.

### DIFF
--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -4,7 +4,7 @@
 
 import logging
 import random
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from timeit import default_timer as timer
 from typing import Callable, Dict, Optional, Tuple
 
@@ -48,7 +48,7 @@ class WrappedCallback:
         self.iterations = 0  # how many times we ran the callback iterator for this callback
 
     def get_current_time_with_cluster_diff(self):
-        return datetime.now() + timedelta(milliseconds=self.cluster_time_diff)
+        return datetime.now(timezone.utc) + timedelta(milliseconds=self.cluster_time_diff)
 
     def __call__(self):
         self.logger.debug(f"Running scheduled callback {self}")
@@ -101,7 +101,7 @@ class WrappedCallback:
 
             now = self.get_current_time_with_cluster_diff()
             random_second = random.randint(5, 55)  # noqa: S311
-            next_execution = datetime.now().replace(second=random_second, microsecond=0)
+            next_execution = datetime.now(timezone.utc).replace(second=random_second, microsecond=0)
             if next_execution <= now:
                 # The random chosen second already passed this minute
                 next_execution += timedelta(minutes=1)

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -212,11 +212,11 @@ class Extension:
 
         # Timestamps for scheduling of internal callbacks
         self._next_internal_callbacks_timestamps: Dict[str, datetime] = {
-            "timediff": datetime.now() + TIME_DIFF_INTERVAL,
-            "heartbeat": datetime.now() + HEARTBEAT_INTERVAL,
-            "metrics": datetime.now() + METRIC_SENDING_INTERVAL,
-            "events": datetime.now() + METRIC_SENDING_INTERVAL,
-            "sfm_metrics": datetime.now() + SFM_METRIC_SENDING_INTERVAL,
+            "timediff": datetime.now(timezone.utc) + TIME_DIFF_INTERVAL,
+            "heartbeat": datetime.now(timezone.utc) + HEARTBEAT_INTERVAL,
+            "metrics": datetime.now(timezone.utc) + METRIC_SENDING_INTERVAL,
+            "events": datetime.now(timezone.utc) + METRIC_SENDING_INTERVAL,
+            "sfm_metrics": datetime.now(timezone.utc) + SFM_METRIC_SENDING_INTERVAL,
         }
 
         # Executors for the callbacks and internal methods
@@ -485,7 +485,7 @@ class Extension:
 
         if metric_type == MetricType.COUNT and timestamp is None:
             # We must report a timestamp for count metrics
-            timestamp = datetime.now()
+            timestamp = datetime.now(timezone.utc)
 
         metric = Metric(key=key, value=value, dimensions=dimensions, metric_type=metric_type, timestamp=timestamp)
         self._add_metric(metric)


### PR DESCRIPTION
I had noticed [`report_event()` defaults to `datetime.now(timezone.utc)`](https://github.com/dynatrace-extensions/dt-extensions-python-sdk/blob/main/dynatrace_extension/sdk/extension.py#L526) but other invocations of `datetime.now()` return tz-naive datetimes, defaulting to system timezone (e.g. [extension.py line 215](https://github.com/dynatrace-extensions/dt-extensions-python-sdk/blob/main/dynatrace_extension/sdk/extension.py#L215)). This PR ensures all calls to `datetime.now()` are tz-aware.

Note that tz-aware and tz-naive datetimes cannot be compared, so additional work may need to be done to ensure all timestamps are dt-aware (must be UTC?).