### PR TITLE
Adds code quality support to the SDK (ruff checks)

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/dynatrace_extension/cli/create/extension_template/extension_name/__main__.py.template
+++ b/dynatrace_extension/cli/create/extension_template/extension_name/__main__.py.template
@@ -2,7 +2,6 @@ from dynatrace_extension import Extension, Status, StatusValue
 
 
 class ExtensionImpl(Extension):
-
     def query(self):
         """
         The query method is automatically scheduled to run every minute
@@ -11,22 +10,24 @@ class ExtensionImpl(Extension):
 
         for endpoint in self.activation_config["endpoints"]:
             url = endpoint["url"]
-            user = endpoint["user"]
-            password = endpoint["password"]
+            # user = endpoint["user"]
+            # password = endpoint["password"]
             self.logger.debug(f"Running endpoint with url '{url}'")
 
             # Your extension code goes here, e.g.
             # response = requests.get(url, auth=(user, password))
 
             # Report metrics with
-            self.report_metric("my_metric", 1, dimensions={"my_dimension": "dimension1"})
+            self.report_metric("metric_key", 1, dimensions={"key": "value"})
 
         self.logger.info("query method ended for %extension_name%.")
 
     def fastcheck(self) -> Status:
         """
-        This is called when the extension runs for the first time.
-        If this AG cannot run this extension, raise an Exception or return StatusValue.ERROR!
+        Use to check if the extension can run.
+        If this Activegate cannot run this extension, you can
+        raise an Exception or return StatusValue.ERROR.
+        This does not run for OneAgent extensions.
         """
         return Status(StatusValue.OK)
 
@@ -35,6 +36,5 @@ def main():
     ExtensionImpl(name="%extension_name%").run()
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/dynatrace_extension/cli/create/extension_template/ruff.toml.template
+++ b/dynatrace_extension/cli/create/extension_template/ruff.toml.template
@@ -1,0 +1,78 @@
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+    "windows.py", # windows run as
+    "windows_runas.py", # windows run as
+    "*grpc.py", # automatically generated grpc files
+    "mureq.py", # a replacement for requests
+    "vendor", # vendored dependencies
+    "alembic", # alembic migrations
+    "oci", # special case for an extension
+    "pymqi", # special case for an extension
+    "lib" # some extensions commit a lib folder
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.10
+target-version = "py310"
+
+[lint]
+select = ["E", "F", "W", "C90", "I", "N", "UP", "B", "A", "FA", "T20", "Q", "RET", "SIM", "ARG", "PTH", "C"]
+ignore = [
+    "T201", # we allow print because these are logged into the extension logs
+     "PTH123" # open is used too frequently to open files
+]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[lint.mccabe]
+# Flag errors (`C901`) whenever the complexity level exceeds 20.
+max-complexity = 20
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+docstring-code-format = false
+docstring-code-line-length = "dynamic"

--- a/dynatrace_extension/cli/create/extension_template/setup.py.template
+++ b/dynatrace_extension/cli/create/extension_template/setup.py.template
@@ -1,5 +1,6 @@
 from pathlib import Path
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 def find_version() -> str:
@@ -9,20 +10,21 @@ def find_version() -> str:
         with open(extension_yaml_path, encoding="utf-8") as f:
             for line in f:
                 if line.startswith("version"):
-                    version = line.split(" ")[-1].strip("\"")
+                    version = line.split(" ")[-1].strip('"')
                     break
     except Exception:
         pass
     return version
 
 
-setup(name="%extension_name%",
-      version=find_version(),
-      description="%Extension_Name% python EF2 extension",
-      author="Dynatrace",
-      packages=find_packages(),
-      python_requires=">=3.10",
-      include_package_data=True,
-      install_requires=["dt-extensions-sdk"],
-      extras_require={"dev": ["dt-extensions-sdk[cli]"]},
-      )
+setup(
+    name="%extension_name%",
+    version=find_version(),
+    description="%Extension_Name% python EF2 extension",
+    author="Dynatrace",
+    packages=find_packages(),
+    python_requires=">=3.10",
+    include_package_data=True,
+    install_requires=["dt-extensions-sdk"],
+    extras_require={"dev": ["dt-extensions-sdk[cli]"]},
+)

--- a/dynatrace_extension/cli/main.py
+++ b/dynatrace_extension/cli/main.py
@@ -425,6 +425,51 @@ def create(extension_name: str, output: Path = typer.Option(None, "--output", "-
     console.print(f"Extension created at {extension_path}", style="bold green")
 
 
+@app.command("format", help="Runs ruff format on the extension code", )
+def fmt(extension_dir: Path = typer.Argument(".", help="Path to the python extension")):
+    """
+    Runs ruff format on the extension code
+
+    :param extension_dir: The directory of the extension, by default this is the current directory
+    """
+    run_process(["ruff", "format", str(extension_dir.resolve())])
+
+
+@app.command(help="Runs ruff check on the extension code")
+def lint(extension_dir: Path = typer.Argument(".", help="Path to the python extension"),
+         fix: bool = typer.Option(False, "--fix", "-f", help="Fix linting issues")):
+    """
+    Runs ruff lint on the extension code
+
+    :param extension_dir: The directory of the extension, by default this is the current directory
+    :param fix: If true, ask ruff to also fix the linting issues
+    """
+    command = ["ruff", "check", "--exit-zero"]
+    if fix:
+        command.append("--fix")
+    command.append(str(extension_dir.resolve()))
+    run_process(command)
+
+
+@app.command(help="Adds ruff rules if they don't exist already")
+def ruff_init(extension_dir: Path = typer.Argument(".", help="Path to the python extension")):
+    """
+    Adds ruff rules if they don't exist already
+
+    :param extension_dir: The directory of the extension, by default this is the current directory
+    """
+
+    if (extension_dir / "ruff.toml").exists():
+        console.print(f"ruff.toml already exists in {extension_dir.resolve()}, skipping", style="bold yellow")
+        return
+    else:
+        # create\extension_template\ruff.toml.template -> extension\ruff.toml
+        ruff_template = Path(__file__).parent / "create" / "extension_template" / "ruff.toml.template"
+        ruff_file = extension_dir / "ruff.toml"
+        shutil.copy(ruff_template, ruff_file)
+        console.print(f"Added ruff.toml to {extension_dir.resolve()}", style="bold green")
+
+
 def run_process(
     command: List[str], cwd: Optional[Path] = None, env: Optional[dict] = None, print_message: Optional[str] = None
 ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-cli = [ "dt-cli>=1.6.13", "typer[all]", "pyyaml"]
+cli = [ "dt-cli>=1.6.13", "typer[all]", "pyyaml", "ruff"]
 
 [project.urls]
 Documentation = "https://github.com/dynatrace-extensions/dt-extensions-python-sdk#readme"


### PR DESCRIPTION
Introduces the commands:

```
dt-sdk format
```

Formats the code using `ruff format` with the rules defined in `ruff.toml`

```
dt-sdk lint [--fix]
```

Runs `ruff check`, optionally fixing automatically.

```
dt-sdk ruff-init
```

Creates the `ruff.toml` file if it doesn't exist already


These are all OPT-IN