### PR TITLE
New method for metric reporting - report_device_metric

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"

--- a/dynatrace_extension/cli/create/extension_template/extension_name/__main__.py.template
+++ b/dynatrace_extension/cli/create/extension_template/extension_name/__main__.py.template
@@ -18,7 +18,7 @@ class ExtensionImpl(Extension):
             # response = requests.get(url, auth=(user, password))
 
             # Report metrics with
-            self.report_metric("metric_key", 1, dimensions={"key": "value"})
+            self.report_device_metric("metric_key", 1, device_address=url, dimensions={"key": "value"})
 
         self.logger.info("query method ended for %extension_name%.")
 

--- a/tests/sdk/test_extension.py
+++ b/tests/sdk/test_extension.py
@@ -48,6 +48,23 @@ class TestExtension(unittest.TestCase):
         self.assertEqual(len(extension._metrics), 1)
         self.assertTrue(extension._metrics[0].startswith("my_metric gauge,1"))
 
+    def test_add_device_metric(self):
+        extension = Extension()
+        extension.logger = MagicMock()
+        extension._running_in_sim = True
+        extension.report_device_metric("my_metric", 1, device_address='192.168.0.123')
+        self.assertEqual(len(extension._metrics), 1)
+        self.assertTrue(extension._metrics[0].startswith('my_metric,device.address="192.168.0.123" gauge,1'))
+
+    def test_add_device_metric_with_dims(self):
+        extension = Extension()
+        extension.logger = MagicMock()
+        extension._running_in_sim = True
+        extension.report_device_metric("my_metric", 1, dimensions={"my_dim": "my_val"}, device_address='192.168.0.123')
+        self.assertEqual(len(extension._metrics), 1)
+        self.assertTrue(extension._metrics[0].startswith('my_metric,my_dim="my_val",device.address="192.168.0.123" gauge,1'))
+
+
     def test_metrics_flushed(self):
         extension = Extension()
         extension._running_in_sim = True


### PR DESCRIPTION
New method for metric reporting -> `report_device_metric`, which puts emphasis on `device.address` dimension.