### PR TITLE
Allow Python src layout

### DIFF
--- a/dynatrace_extension/cli/main.py
+++ b/dynatrace_extension/cli/main.py
@@ -163,7 +163,8 @@ def assemble(
 
     # Checks that the module name is valid and exists in the filesystem
     module_folder = Path(extension_dir) / extension_yaml.python.runtime.module
-    if not module_folder.exists():
+    src_module_folder = Path('src') / module_folder
+    if not module_folder.exists() and not src_module_folder.exists():
         msg = f"Extension module folder {module_folder} not found"
         raise FileNotFoundError(msg)
 


### PR DESCRIPTION
Allow modules to be in `src` directory, rather than requiring Python flat-layout

I have tested this in my own environment.