### PR TITLE
Optional device_address field in report_metric()

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -457,6 +457,7 @@ class Extension:
         key: str,
         value: Union[float, str, int, SummaryStat],
         dimensions: Optional[Dict[str, str]] = None,
+        device_address: Optional[str] = None,
         techrule: Optional[str] = None,
         timestamp: Optional[datetime] = None,
         metric_type: MetricType = MetricType.GAUGE,
@@ -472,6 +473,7 @@ class Extension:
             key: The metric key, must follow the MINT specification
             value: The metric value, can be a simple value or a SummaryStat
             dimensions: A dictionary of dimensions
+            device_address: The address of a monitored device/endpoint which produced the metric
             techrule: The technology rule string set by self.techrule setter.
             timestamp: The timestamp of the metric, defaults to the current time
             metric_type: The type of the metric, defaults to MetricType.GAUGE
@@ -482,6 +484,12 @@ class Extension:
                 dimensions = {}
             if "dt.techrule.id" not in dimensions:
                 dimensions["dt.techrule.id"] = techrule
+
+        if device_address:
+            if not dimensions:
+                dimensions = {}
+            if "device.address" not in dimensions:
+                dimensions["device.address"] = device_address
 
         if metric_type == MetricType.COUNT and timestamp is None:
             # We must report a timestamp for count metrics

--- a/tests/sdk/test_extension.py
+++ b/tests/sdk/test_extension.py
@@ -48,6 +48,15 @@ class TestExtension(unittest.TestCase):
         self.assertEqual(len(extension._metrics), 1)
         self.assertTrue(extension._metrics[0].startswith("my_metric gauge,1"))
 
+    def test_add_metric_with_device_address(self):
+        extension = Extension()
+        extension.logger = MagicMock()
+        extension._running_in_sim = True
+        extension.report_metric("my_metric", 1, device_address="10.10.10.10")
+        print(extension._metrics[0])
+        self.assertEqual(len(extension._metrics), 1)
+        self.assertTrue(extension._metrics[0].startswith('my_metric,device.address="10.10.10.10" gauge,1'))
+
     def test_metrics_flushed(self):
         extension = Extension()
         extension._running_in_sim = True


### PR DESCRIPTION
Optional `device_address` field in `report_metric()` method.