### PR TITLE
Include extra useful entry properties when parsing snapshot

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/dynatrace_extension/cli/create/create.py
+++ b/dynatrace_extension/cli/create/create.py
@@ -2,7 +2,7 @@ import os
 import re
 import shutil
 from pathlib import Path
-from typing import Final, List, NamedTuple, Tuple
+from typing import Final, NamedTuple
 
 output_mode_folder: Final = 0o755
 output_mode_file: Final = 0o644
@@ -14,7 +14,7 @@ class ReplaceString(NamedTuple):
     replace: str
 
 
-def replace_placeholders(file: Path, replaces: List[Tuple[str, str]]):
+def replace_placeholders(file: Path, replaces: list[tuple[str, str]]):
     with open(file) as f:
         contents = f.read()
     for replace in replaces:

--- a/dynatrace_extension/cli/main.py
+++ b/dynatrace_extension/cli/main.py
@@ -4,7 +4,6 @@ import stat
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Optional
 
 import typer
 from dtcli.server_api import upload as dt_cli_upload  # type: ignore
@@ -91,17 +90,17 @@ def build(
         "-k",
         help="Path to the dev fused key-certificate",
     ),
-    target_directory: Optional[Path] = typer.Option(None, "--target-directory", "-t"),
-    extra_platforms: Optional[list[str]] = typer.Option(
+    target_directory: Path | None = typer.Option(None, "--target-directory", "-t"),
+    extra_platforms: list[str] | None = typer.Option(
         None, "--extra-platform", "-e", help="Download wheels for an extra platform"
     ),
-    extra_index_url: Optional[str] = typer.Option(
+    extra_index_url: str | None = typer.Option(
         None, "--extra-index-url", "-i", help="Extra index url to use when downloading dependencies"
     ),
-    find_links: Optional[str] = typer.Option(
+    find_links: str | None = typer.Option(
         None, "--find-links", "-f", help="Extra index url to use when downloading dependencies"
     ),
-    only_extra_platforms: Optional[bool] = typer.Option(
+    only_extra_platforms: bool | None = typer.Option(
         False,
         "--only-extra-platforms",
         "-o",
@@ -163,7 +162,7 @@ def assemble(
 
     # Checks that the module name is valid and exists in the filesystem
     module_folder = Path(extension_dir) / extension_yaml.python.runtime.module
-    src_module_folder = Path('src') / module_folder
+    src_module_folder = Path("src") / module_folder
     if not module_folder.exists() and not src_module_folder.exists():
         msg = f"Extension module folder {module_folder} not found"
         raise FileNotFoundError(msg)
@@ -188,16 +187,16 @@ def assemble(
 @app.command(help="Downloads the dependencies of the extension to the lib folder")
 def wheel(
     extension_dir: Path = typer.Argument(".", help="Path to the python extension"),
-    extra_platforms: Optional[list[str]] = typer.Option(
+    extra_platforms: list[str] | None = typer.Option(
         None, "--extra-platform", "-e", help="Download wheels for an extra platform"
     ),
-    extra_index_url: Optional[str] = typer.Option(
+    extra_index_url: str | None = typer.Option(
         None, "--extra-index-url", "-i", help="Extra index url to use when downloading dependencies"
     ),
-    find_links: Optional[str] = typer.Option(
+    find_links: str | None = typer.Option(
         None, "--find-links", "-f", help="Extra index url to use when downloading dependencies"
     ),
-    only_extra_platforms: Optional[bool] = typer.Option(
+    only_extra_platforms: bool | None = typer.Option(
         False,
         "--only-extra-platforms",
         "-o",
@@ -476,9 +475,7 @@ def ruff_init(extension_dir: Path = typer.Argument(".", help="Path to the python
         console.print(f"Added ruff.toml to {extension_dir.resolve()}", style="bold green")
 
 
-def run_process(
-    command: List[str], cwd: Optional[Path] = None, env: Optional[dict] = None, print_message: Optional[str] = None
-):
+def run_process(command: list[str], cwd: Path | None = None, env: dict | None = None, print_message: str | None = None):
     friendly_command = " ".join(command)
     if print_message is not None:
         console.print(print_message, style="cyan")

--- a/dynatrace_extension/sdk/activation.py
+++ b/dynatrace_extension/sdk/activation.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 from enum import Enum
-from typing import List
 
 
 class ActivationType(Enum):
@@ -17,7 +16,7 @@ class ActivationConfig(dict):
         self.version: str = self._activation_context_json.get("version", "")
         self.enabled: bool = self._activation_context_json.get("enabled", True)
         self.description: str = self._activation_context_json.get("description", "")
-        self.feature_sets: List[str] = self._activation_context_json.get("featureSets", [])
+        self.feature_sets: list[str] = self._activation_context_json.get("featureSets", [])
         self.type: ActivationType = ActivationType.REMOTE if self.remote else ActivationType.LOCAL
         super().__init__()
 

--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -4,9 +4,9 @@
 
 import logging
 import random
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from timeit import default_timer as timer
-from typing import Callable, Dict, Optional, Tuple
 
 from .activation import ActivationType
 from .communication import MultiStatus, Status, StatusValue
@@ -18,10 +18,10 @@ class WrappedCallback:
         interval: timedelta,
         callback: Callable,
         logger: logging.Logger,
-        args: Optional[Tuple] = None,
-        kwargs: Optional[Dict] = None,
+        args: tuple | None = None,
+        kwargs: dict | None = None,
         running_in_sim=False,
-        activation_type: Optional[ActivationType] = None,
+        activation_type: ActivationType | None = None,
     ):
         self.callback: Callable = callback
         if args is None:

--- a/dynatrace_extension/sdk/communication.py
+++ b/dynatrace_extension/sdk/communication.py
@@ -8,16 +8,17 @@ import json
 import logging
 import sys
 from abc import ABC, abstractmethod
+from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, Generator, List, Sequence, TypeVar
+from typing import Any, TypeVar
 
 from .vendor.mureq.mureq import HTTPException, Response, request
 
 CONTENT_TYPE_JSON = "application/json;charset=utf-8"
 CONTENT_TYPE_PLAIN = "text/plain;charset=utf-8"
-COUNT_METRIC_ITEMS_DICT = TypeVar("COUNT_METRIC_ITEMS_DICT", str, List[str])
+COUNT_METRIC_ITEMS_DICT = TypeVar("COUNT_METRIC_ITEMS_DICT", str, list[str])
 
 # TODO - I believe these can be adjusted via RuntimeConfig, they can't be constants
 MAX_MINT_LINES_PER_REQUEST = 1000
@@ -60,7 +61,6 @@ class Status:
 
 
 class MultiStatus:
-
     def __init__(self):
         self.statuses = []
 
@@ -352,7 +352,6 @@ class DebugClient(CommunicationClient):
         local_ingest_port: int = 14499,
         print_metrics: bool = True,
     ):
-
         self.secrets = {}
         if secrets_path and Path(secrets_path).exists():
             with open(secrets_path) as f:

--- a/dynatrace_extension/sdk/helper.py
+++ b/dynatrace_extension/sdk/helper.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Callable, Dict, List, Optional, Union
 
 from .activation import ActivationConfig, ActivationType
 from .communication import Status
@@ -20,10 +20,10 @@ class _HelperExtension(Extension):
 
 def report_metric(
     key: str,
-    value: Union[float, str, int, SummaryStat],
-    dimensions: Optional[Dict[str, str]] = None,
-    techrule: Optional[str] = None,
-    timestamp: Optional[datetime] = None,
+    value: float | str | int | SummaryStat,
+    dimensions: dict[str, str] | None = None,
+    techrule: str | None = None,
+    timestamp: datetime | None = None,
     metric_type: MetricType = MetricType.GAUGE,
 ) -> None:
     """Reports a metric using the MINT protocol
@@ -37,10 +37,10 @@ def report_metric(
     :param timestamp: The timestamp of the metric, defaults to the current time
     :param metric_type: The type of the metric, defaults to MetricType.GAUGE
     """
-    _HelperExtension().report_metric(key, value, dimensions, techrule, timestamp, metric_type)
+    _HelperExtension().report_metric(key, value, dimensions, techrule, timestamp, metric_type)  # type: ignore
 
 
-def report_mint_lines(lines: List[str]) -> None:
+def report_mint_lines(lines: list[str]) -> None:
     """Reports mint lines using the MINT protocol.
     These lines are not validated before being sent.
 
@@ -52,11 +52,11 @@ def report_mint_lines(lines: List[str]) -> None:
 def report_dt_event(
     event_type: DtEventType,
     title: str,
-    start_time: Optional[int] = None,
-    end_time: Optional[int] = None,
-    timeout: Optional[int] = None,
-    entity_selector: Optional[str] = None,
-    properties: Optional[dict[str, str]] = None,
+    start_time: int | None = None,
+    end_time: int | None = None,
+    timeout: int | None = None,
+    entity_selector: str | None = None,
+    properties: dict[str, str] | None = None,
 ) -> None:
     """
     Reports a custom event v2 using event ingest
@@ -85,9 +85,9 @@ def report_dt_event_dict(event: dict):
 
 def schedule(
     callback: Callable,
-    interval: Union[timedelta, int],
-    args: Optional[tuple] = None,
-    activation_type: Optional[ActivationType] = None,
+    interval: timedelta | int,
+    args: tuple | None = None,
+    activation_type: ActivationType | None = None,
 ) -> None:
     """Schedules a callback to be called periodically
 
@@ -101,7 +101,7 @@ def schedule(
 
 
 def schedule_function(
-    interval: Union[timedelta, int], args: Optional[tuple] = None, activation_type: Optional[ActivationType] = None
+    interval: timedelta | int, args: tuple | None = None, activation_type: ActivationType | None = None
 ):
     def decorator(function):
         schedule(function, interval, args=args, activation_type=activation_type)
@@ -110,7 +110,7 @@ def schedule_function(
 
 
 def schedule_method(
-    interval: Union[timedelta, int], args: Optional[tuple] = None, activation_type: Optional[ActivationType] = None
+    interval: timedelta | int, args: tuple | None = None, activation_type: ActivationType | None = None
 ):
     def decorator(function):
         Extension.schedule_decorators.append((function, interval, args, activation_type))
@@ -121,9 +121,9 @@ def schedule_method(
 def report_event(
     title: str,
     description: str,
-    properties: Optional[dict] = None,
-    timestamp: Optional[datetime] = None,
-    severity: Union[Severity, str] = Severity.INFO,
+    properties: dict | None = None,
+    timestamp: datetime | None = None,
+    severity: Severity | str = Severity.INFO,
 ) -> None:
     """Reports an event using the MINT protocol
 
@@ -144,7 +144,7 @@ def report_log_event(log_event: dict):
     _HelperExtension().report_log_event(log_event)
 
 
-def report_log_events(log_events: List[dict]):
+def report_log_events(log_events: list[dict]):
     """Reports a list of custom log events using log ingest
 
     :param log_events: The list of log events
@@ -152,7 +152,7 @@ def report_log_events(log_events: List[dict]):
     _HelperExtension().report_log_events(log_events)
 
 
-def report_log_lines(log_lines: List[Union[str, bytes]]):
+def report_log_lines(log_lines: list[str | bytes]):
     """Reports a list of log lines using log ingest
 
     :param log_lines: The list of log lines

--- a/dynatrace_extension/sdk/metric.py
+++ b/dynatrace_extension/sdk/metric.py
@@ -4,7 +4,6 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Dict, Optional, Union
 
 # https://bitbucket.lab.dynatrace.org/projects/ONE/repos/schemaless-metrics-spec/browse/limits.md
 LIMIT_DIMENSIONS_COUNT = 50
@@ -41,18 +40,18 @@ class Metric:
     def __init__(
         self,
         key: str,
-        value: Union[float, int, str, SummaryStat],
-        dimensions: Optional[Dict[str, str]] = None,
+        value: float | int | str | SummaryStat,
+        dimensions: dict[str, str] | None = None,
         metric_type: MetricType = MetricType.GAUGE,
-        timestamp: Optional[datetime] = None,
+        timestamp: datetime | None = None,
     ):
         self.key: str = key
-        self.value: Union[float, int, str, SummaryStat] = value
+        self.value: float | int | str | SummaryStat = value
         if dimensions is None:
             dimensions = {}
-        self.dimensions: Dict[str, str] = dimensions
+        self.dimensions: dict[str, str] = dimensions
         self.metric_type: MetricType = metric_type
-        self.timestamp: Optional[datetime] = timestamp
+        self.timestamp: datetime | None = timestamp
 
     def __hash__(self):
         return hash(self._key_and_dimensions())
@@ -103,10 +102,10 @@ class SfmMetric(Metric):
     def __init__(
         self,
         key: str,
-        value: Union[float, int, str, SummaryStat],
-        dimensions: Optional[Dict[str, str]] = None,
+        value: float | int | str | SummaryStat,
+        dimensions: dict[str, str] | None = None,
         metric_type: MetricType = MetricType.GAUGE,
-        timestamp: Optional[datetime] = None,
+        timestamp: datetime | None = None,
         client_facing: bool = False,
     ):
         key = create_sfm_metric_key(key, client_facing)

--- a/dynatrace_extension/sdk/runtime.py
+++ b/dynatrace_extension/sdk/runtime.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-from typing import ClassVar, List, NamedTuple
+from typing import ClassVar, NamedTuple
 
 
 class DefaultLogLevel(NamedTuple):
@@ -25,7 +25,7 @@ class RuntimeProperties:
         self.userconfig: str = json_response.get("userconfig", "")
         self.debugmode: bool = json_response.get("debugmode", "0") == "1"
         self.runtime: dict = json_response.get("runtime", {})
-        self.tasks: List[str] = json_response.get("tasks", [])
+        self.tasks: list[str] = json_response.get("tasks", [])
 
     @classmethod
     def set_default_log_level(cls, value: str):

--- a/dynatrace_extension/sdk/snapshot.py
+++ b/dynatrace_extension/sdk/snapshot.py
@@ -14,10 +14,10 @@ PREFIX_PGI = "PROCESS_GROUP_INSTANCE"
 class EntryProperties:
     technologies: list[str]
     pg_technologies: list[str]
-    extra_properties: dict[str,str]
+    extra_properties: dict[str, str]
 
     @staticmethod
-    def from_json(json_data: dict[str,str]) -> EntryProperties:
+    def from_json(json_data: dict[str, str]) -> EntryProperties:
         technologies = json_data.get("Technologies", "").split(",")
         pg_technologies = json_data.get("pgTechnologies", "").split(",")
         extra_properties = {k: v for k, v in json_data.items() if k not in ["Technologies", "pgTechnologies"]}
@@ -113,7 +113,7 @@ class Entry:
         processes = [Process.from_json(p) for p in json_data.get("processes", [])]
 
         # The structure here was never thought out, so we have to check for both keys and merge them into one object
-        properties_list: list[dict[str,str]] = json_data.get("properties", [])
+        properties_list: list[dict[str, str]] = json_data.get("properties", [])
         technologies = []
         pg_technologies = []
         # There may be other useful properties included such as: mssql_instance_name.
@@ -123,9 +123,9 @@ class Entry:
             for key, value in prop.items():
                 match key:
                     case "Technologies":
-                            technologies.extend(value.split(","))
+                        technologies.extend(value.split(","))
                     case "pgTechnologies":
-                            pg_technologies.extend(value.split(","))
+                        pg_technologies.extend(value.split(","))
                     case _:
                         extra_properties[key] = value
 
@@ -135,7 +135,6 @@ class Entry:
 
 
 @dataclass
-
 class Snapshot:
     host_id: str
     entries: list[Entry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,12 +116,12 @@ rebuild = [
 ]
 
 [tool.black]
-target-version = ["py37"]
+target-version = ["py310"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py310"
 line-length = 160
 select = [
     "A",

--- a/tests/sdk/test_communication.py
+++ b/tests/sdk/test_communication.py
@@ -28,7 +28,6 @@ class TestCommunication(unittest.TestCase):
         self.assertEqual(len(responses), 0)
 
     def test_large_log_chunk(self):
-
         # This is 14_660_000 bytes
         events = []
         for _ in range(5000):
@@ -58,7 +57,6 @@ class TestCommunication(unittest.TestCase):
         self.assertEqual(len(chunks[0]), 1720)
 
     def test_large_metric_chunk(self):
-
         metrics = ['my.metric,dim="dim" 10'] * 500 * 100
 
         # it needs to be divided into 2 lists, each with 650_000 bytes
@@ -81,7 +79,6 @@ class TestCommunication(unittest.TestCase):
         self.assertEqual(len(chunks), 0)
 
     def test_large_log_chunk_valid_json(self):
-
         events = []
         for _ in range(5000):
             attributes = {}

--- a/tests/sdk/test_extension.py
+++ b/tests/sdk/test_extension.py
@@ -53,7 +53,6 @@ class TestExtension(unittest.TestCase):
         extension.logger = MagicMock()
         extension._running_in_sim = True
         extension.report_metric("my_metric", 1, device_address="10.10.10.10")
-        print(extension._metrics[0])
         self.assertEqual(len(extension._metrics), 1)
         self.assertTrue(extension._metrics[0].startswith('my_metric,device.address="10.10.10.10" gauge,1'))
 

--- a/tests/sdk/test_runtime_properties.py
+++ b/tests/sdk/test_runtime_properties.py
@@ -1,6 +1,6 @@
 import logging
 import unittest
-from typing import Any, Dict
+from typing import Any
 
 from dynatrace_extension import Extension
 from dynatrace_extension.sdk.runtime import RuntimeProperties
@@ -11,7 +11,7 @@ class TestRuntimeProperties(unittest.TestCase):
         Extension._instance = None
 
     def test_api_log_level(self) -> None:
-        response_json: Dict[str, Any] = {"runtime": {}}
+        response_json: dict[str, Any] = {"runtime": {}}
         response_json["runtime"]["debuglevel.extension1.api"] = "debug"  # converted to debug
         response_json["runtime"]["debuglevel.extension2.api"] = "WARNING"  # wrong value - default to info
 

--- a/tests/sdk/test_status.py
+++ b/tests/sdk/test_status.py
@@ -113,7 +113,6 @@ class TestStatus(unittest.TestCase):
         self.assertIn("foo1", status.message)
 
     def test_direct_statuses_return(self):
-
         def callback():
             return Status(StatusValue.OK, "foo1")
 


### PR DESCRIPTION
Snapshot entries can sometimes include other properties such as `mssql_instance_name` which can be useful. In this example the instance name is used to determine the performance counter prefix.

Needed to replace the old EF1 logic of:
```
self.entity = kwargs["associated_entity"]
instance_name = self.entity.properties['mssql_instance_name']
```

This adds those properties to a dictionary called: `extra_properties`
Accessible via:
```
  snapshot = self.get_snapshot()
  for mssql_entry in snapshot.get_process_groups_by_technology("MSSQL"):
      mssql_instance_name = mssql_entry.properties.extra_properties.get("mssql_instance_name")
```

Example snapshot with SQLEXPRESS
```
{
    "host_id": "0XC5B095DDA1FA0E61",
    "entries": [
        {
            "group_id": "0X8D6D1890DCD1FAA2",
            "node_id": "0X0000000000000000",
            "group_instance_id": "0X783C15D8FC8D78CD",
            "process_type": "6",
            "group_name": "MSSQL16.SQLEXPRESS",
            "processes": [
                {
                    "pid": "19492",
                    "process_name": "sqlservr.exe",
                    "properties": [
                        {
                            "WorkDir": "C:\\WINDOWS\\system32\\"
                        },
                        {
                            "CmdLine": "-sSQLEXPRESS"
                        },
                        {
                            "ExePath": "C:\\Program Files\\Microsoft SQL Server\\MSSQL16.SQLEXPRESS\\MSSQL\\Binn\\sqlservr.exe"
                        },
                        {
                            "ParentPid": "1680"
                        }
                    ]
                },
                {
                    "pid": "24500",
                    "process_name": "sqlceip.exe",
                    "properties": [
                        {
                            "WorkDir": "C:\\WINDOWS\\system32\\"
                        },
                        {
                            "CmdLine": "-Service SQLEXPRESS"
                        },
                        {
                            "ExePath": "C:\\Program Files\\Microsoft SQL Server\\MSSQL16.SQLEXPRESS\\MSSQL\\Binn\\sqlceip.exe"
                        },
                        {
                            "ParentPid": "1680"
                        }
                    ]
                }
            ],
            "properties": [
                {
                    "mssql_instance_name": "SQLEXPRESS"
                },
                {
                    "Technologies": "MSSQL,MSSQL,DOTNET,CLR"
                },
                {
                    "pgTechnologies": ".NET,CLR,Microsoft SQL Server"
                }
            ]
        }
    ],
    "containers": []
}
```