### PR TITLE
fix an issue with the order of the arguments in report_metric

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -458,10 +458,10 @@ class Extension:
         key: str,
         value: float | str | int | SummaryStat,
         dimensions: dict[str, str] | None = None,
-        device_address: str | None = None,
         techrule: str | None = None,
         timestamp: datetime | None = None,
         metric_type: MetricType = MetricType.GAUGE,
+        device_address: str | None = None,
     ) -> None:
         """Report a metric.
 


### PR DESCRIPTION
We can't introduce new arguments "earlier" in ordering than others, it will break extensions

Moving device_address to the last argument