### PR TITLE
Feature/endpoint statuses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+# VSCode
+.vscode/
+
 test_temp/
 
 # Thumbnails

--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"

--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"

--- a/dynatrace_extension/__init__.py
+++ b/dynatrace_extension/__init__.py
@@ -6,7 +6,7 @@
 # ruff: noqa: F401
 
 from .sdk.activation import ActivationConfig, ActivationType
-from .sdk.communication import Status, StatusValue, EndpointStatuses, EndpointStatus, EndpointSeverity, IgnoreStatus, MultiStatus
+from .sdk.communication import Status, StatusValue, EndpointStatuses, EndpointStatus, IgnoreStatus, MultiStatus
 from .sdk.event import Severity
 from .sdk.extension import DtEventType, Extension
 from .sdk.helper import (

--- a/dynatrace_extension/__init__.py
+++ b/dynatrace_extension/__init__.py
@@ -6,7 +6,7 @@
 # ruff: noqa: F401
 
 from .sdk.activation import ActivationConfig, ActivationType
-from .sdk.communication import Status, StatusValue, EndpointStatuses, EndpointStatus, IgnoreStatus, MultiStatus
+from .sdk.communication import EndpointStatus, EndpointStatuses, IgnoreStatus, MultiStatus, Status, StatusValue
 from .sdk.event import Severity
 from .sdk.extension import DtEventType, Extension
 from .sdk.helper import (

--- a/dynatrace_extension/__init__.py
+++ b/dynatrace_extension/__init__.py
@@ -6,7 +6,7 @@
 # ruff: noqa: F401
 
 from .sdk.activation import ActivationConfig, ActivationType
-from .sdk.communication import Status, StatusValue
+from .sdk.communication import Status, StatusValue, EndpointStatuses, EndpointStatus, EndpointSeverity, IgnoreStatus, MultiStatus
 from .sdk.event import Severity
 from .sdk.extension import DtEventType, Extension
 from .sdk.helper import (

--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from timeit import default_timer as timer
 
 from .activation import ActivationType
-from .communication import EndpointStatuses, MultiStatus, Status, StatusValue, IgnoreStatus
+from .communication import EndpointStatuses, IgnoreStatus, MultiStatus, Status, StatusValue
 
 
 class WrappedCallback:

--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -66,7 +66,7 @@ class WrappedCallback:
             elif isinstance(ret, MultiStatus):
                 self.status = ret.build()
             elif isinstance(ret, EndpointStatuses):
-                self.status = Status(ret.get_status_value(), ret.get_message())
+                self.status = ret.build_common_status()
             else:
                 self.status = Status(StatusValue.OK)
         except Exception as e:

--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from timeit import default_timer as timer
 
 from .activation import ActivationType
-from .communication import EndpointStatuses, MultiStatus, Status, StatusValue
+from .communication import EndpointStatuses, MultiStatus, Status, StatusValue, IgnoreStatus
 
 
 class WrappedCallback:
@@ -66,7 +66,9 @@ class WrappedCallback:
             elif isinstance(ret, MultiStatus):
                 self.status = ret.build()
             elif isinstance(ret, EndpointStatuses):
-                self.status = ret.build_common_status()
+                self.status = ret
+            elif isinstance(ret, IgnoreStatus):
+                self.status = ret
             else:
                 self.status = Status(StatusValue.OK)
         except Exception as e:

--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from timeit import default_timer as timer
 
 from .activation import ActivationType
-from .communication import MultiStatus, Status, StatusValue
+from .communication import EndpointStatuses, MultiStatus, Status, StatusValue
 
 
 class WrappedCallback:
@@ -65,6 +65,8 @@ class WrappedCallback:
                 self.status = ret
             elif isinstance(ret, MultiStatus):
                 self.status = ret.build()
+            elif isinstance(ret, EndpointStatuses):
+                self.status = Status(ret.get_status_value(), ret.get_message())
             else:
                 self.status = Status(StatusValue.OK)
         except Exception as e:

--- a/dynatrace_extension/sdk/communication.py
+++ b/dynatrace_extension/sdk/communication.py
@@ -46,6 +46,7 @@ class StatusValue(Enum):
 class IgnoreStatus:
     pass
 
+
 class Status:
     def __init__(self, status: StatusValue = StatusValue.EMPTY, message: str = "", timestamp: int | None = None):
         self.status = status
@@ -71,7 +72,7 @@ class Status:
 
 class MultiStatus:
     def __init__(self):
-        self.statuses: list[StatusValue] = []
+        self.statuses: list[Status] = []
 
     def add_status(self, status: StatusValue, message):
         self.statuses.append(Status(status, message))
@@ -136,7 +137,7 @@ class EndpointStatuses:
         self._num_endpoints = total_endpoints_number
 
     def add_endpoint_status(self, status: EndpointStatus):
-        with (self._lock):
+        with self._lock:
             if status.status == StatusValue.OK:
                 self.clear_endpoint_error(status.endpoint)
             else:
@@ -164,7 +165,9 @@ class EndpointStatuses:
                         self._faulty_endpoints[endpoint] = status
                     else:
                         self._num_endpoints -= 1
-                        raise EndpointStatuses.MergeConflictError(self._faulty_endpoints[endpoint], other._faulty_endpoints[endpoint])
+                        raise EndpointStatuses.MergeConflictError(
+                            self._faulty_endpoints[endpoint], other._faulty_endpoints[endpoint]
+                        )
 
     def build_common_status(self) -> Status:
         with self._lock:
@@ -176,9 +179,7 @@ class EndpointStatuses:
 
             error_messages = []
             for ep_status in self._faulty_endpoints.values():
-                error_messages.append(
-                    f"{ep_status.endpoint} - {ep_status.status.value} {ep_status.message}"
-                )
+                error_messages.append(f"{ep_status.endpoint} - {ep_status.status.value} {ep_status.message}")
             common_msg = ", ".join(error_messages)
 
             # Determine status value

--- a/dynatrace_extension/sdk/communication.py
+++ b/dynatrace_extension/sdk/communication.py
@@ -98,7 +98,7 @@ class MultiStatus:
             else:
                 all_err = False
 
-        ret.message = "\n".join(messages)
+        ret.message = ", ".join(messages)
 
         if any_warning:
             ret.status = StatusValue.WARNING

--- a/dynatrace_extension/sdk/communication.py
+++ b/dynatrace_extension/sdk/communication.py
@@ -43,12 +43,6 @@ class StatusValue(Enum):
     UNKNOWN_ERROR = "UNKNOWN_ERROR"
 
 
-class EndpointSeverity(Enum):
-    INFO = "INFO"
-    WARNING = "WARNING"
-    ERROR = "ERROR"
-
-
 class IgnoreStatus:
     pass
 
@@ -118,9 +112,8 @@ class MultiStatus:
 
 
 class EndpointStatus:
-    def __init__(self, endpoint_hint: str, severity: EndpointSeverity, short_status: StatusValue, message: str):
+    def __init__(self, endpoint_hint: str, short_status: StatusValue, message: str):
         self.endpoint = endpoint_hint
-        self.severity: EndpointSeverity = severity
         self.short_status: StatusValue = short_status
         self.message = message
 

--- a/dynatrace_extension/sdk/communication.py
+++ b/dynatrace_extension/sdk/communication.py
@@ -89,14 +89,14 @@ class MultiStatus:
         messages = []
         all_ok = True
         all_err = True
-        warning_occured = False
+        any_warning = False
 
         for stored_status in self.statuses:
             if stored_status.message != "":
                 messages.append(stored_status.message)
 
             if stored_status.is_warning():
-                warning_occured = True
+                any_warning = True
 
             if stored_status.is_error():
                 all_ok = False
@@ -105,7 +105,7 @@ class MultiStatus:
 
         ret.message = "\n".join(messages)
 
-        if warning_occured:
+        if any_warning:
             ret.status = StatusValue.WARNING
         elif all_ok:
             ret.status = StatusValue.OK

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -20,7 +20,7 @@ from typing import Any, ClassVar, NamedTuple
 
 from .activation import ActivationConfig, ActivationType
 from .callback import WrappedCallback
-from .communication import CommunicationClient, DebugClient, HttpClient, Status, StatusValue
+from .communication import CommunicationClient, DebugClient, HttpClient, Status, StatusValue, MultiStatus, EndpointStatus, EndpointStatuses, EndpointSeverity
 from .event import Severity
 from .metric import Metric, MetricType, SfmMetric, SummaryStat
 from .runtime import RuntimeProperties

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -1026,7 +1026,7 @@ class Extension:
                 all_err = False
 
             if callback.status.is_error() or (callback.status.message is not None and callback.status.message != ""):
-                messages.append(f"{callback}: {callback.status.status.value} - {callback.status.message}")
+                messages.append(f"{callback.name()}: {callback.status.status.value} - {callback.status.message}")
 
         # Handle merged EndpointStatuses
         if ep_status_merged._num_endpoints > 0:

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -1014,7 +1014,7 @@ class Extension:
                 try:
                     ep_status_merged.merge(callback.status)
                 except EndpointStatuses.MergeConflictError as e:
-                    self.logger(e)
+                    self.logger.exception(e)
                 continue
 
             if callback.status.is_warning():

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -20,7 +20,7 @@ from typing import Any, ClassVar, NamedTuple
 
 from .activation import ActivationConfig, ActivationType
 from .callback import WrappedCallback
-from .communication import CommunicationClient, DebugClient, HttpClient, Status, StatusValue, MultiStatus, EndpointStatus, EndpointStatuses, EndpointSeverity
+from .communication import CommunicationClient, DebugClient, HttpClient, Status, StatusValue, MultiStatus, EndpointStatus, EndpointStatuses, EndpointSeverity, IgnoreStatus
 from .event import Severity
 from .metric import Metric, MetricType, SfmMetric, SummaryStat
 from .runtime import RuntimeProperties
@@ -380,7 +380,7 @@ class Extension:
         Optional method that can be implemented by subclasses.
         The query method is always scheduled to run every minute.
         """
-        pass
+        return IgnoreStatus()
 
     def initialize(self):
         """Callback to be executed when the extension starts.
@@ -980,33 +980,80 @@ class Extension:
                 )
 
     def _build_current_status(self):
-        overall_status = Status(StatusValue.OK)
-
         if self._initialization_error:
-            overall_status.status = StatusValue.GENERIC_ERROR
-            overall_status.message = self._initialization_error
-            return overall_status
+            return Status(StatusValue.OK, self._initialization_error)
 
-        internal_callback_error = False
         messages = []
-        with self._internal_callbacks_results_lock:
+
+        # TODO: separate
+        # Check for internal errors
+        with self._internal_callbacks_results_lock:            
+            overall_status_value = Status(StatusValue.OK)
+            internal_callback_error = False
+            
             for callback, result in self._internal_callbacks_results.items():
                 if result.is_error():
                     internal_callback_error = True
-                    overall_status.status = result.status
-                    messages.append(f"{callback}: {result.message}")
+                    overall_status_value = result.status
+                    messages.append(f"{callback}: {result.status} - {result.message}")
+            
             if internal_callback_error:
-                overall_status.message = "\n".join(messages)
-                return overall_status
+                return Status(overall_status_value, "\n".join(messages))
+
+
+        # Handle regular statuses, merge all EndpointStatuses
+        ep_status_merged = EndpointStatuses(0)
+        # TODO: what if all are WARNINGs? Or there's only a single warning status (eg from MultiStatsu)
+        all_ok = True
+        all_err = True
+        warning_occured = False
 
         for callback in self._scheduled_callbacks:
-            if callback.status.is_error():
-                overall_status.status = callback.status.status
-                messages.append(f"{callback}: {callback.status.message}")
+            if isinstance(callback.status, IgnoreStatus):
                 continue
-            if callback.status.message is not None and callback.status.message != "":
-                messages.append(f"{callback}: {callback.status.message}")
-        overall_status.message = "\n".join(messages)
+
+            if isinstance(callback.status, EndpointStatuses):
+                try:
+                    ep_status_merged.merge(callback.status)
+                except EndpointStatuses.MergeConflict as e:
+                    self.logger(e)
+                continue
+
+            if callback.status.is_warning():
+                warning_occured = True
+
+            if callback.status.is_error():
+                all_ok = False
+            else:
+                all_err = False
+
+            if callback.status.is_error() or (callback.status.message is not None and callback.status.message != ""):                
+                messages.append(f"{callback}: {callback.status.status.value} - {callback.status.message}")        
+
+        # Handle merged EndpointStatuses
+        if ep_status_merged._num_endpoints > 0:
+            ep_status_merged = ep_status_merged.build_common_status()
+            messages.append(ep_status_merged.message)
+            
+            if ep_status_merged.is_warning():
+                warning_occured = True
+
+            if ep_status_merged.is_error():
+                all_ok = False
+            else:
+                all_err = False
+
+        # Build overall status
+        overall_status = Status(StatusValue.OK, "\n".join(messages))
+        if warning_occured:
+            overall_status.status = StatusValue.WARNING
+        elif all_ok:
+            overall_status.status = StatusValue.OK
+        elif all_err:
+            overall_status.status = StatusValue.GENERIC_ERROR
+        else:
+            overall_status.status = StatusValue.WARNING
+
         return overall_status
 
     def _update_cluster_time_diff(self):

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -20,7 +20,15 @@ from typing import Any, ClassVar, NamedTuple
 
 from .activation import ActivationConfig, ActivationType
 from .callback import WrappedCallback
-from .communication import CommunicationClient, DebugClient, EndpointStatuses, HttpClient, IgnoreStatus, Status, StatusValue
+from .communication import (
+    CommunicationClient,
+    DebugClient,
+    EndpointStatuses,
+    HttpClient,
+    IgnoreStatus,
+    Status,
+    StatusValue,
+)
 from .event import Severity
 from .metric import Metric, MetricType, SfmMetric, SummaryStat
 from .runtime import RuntimeProperties
@@ -998,7 +1006,6 @@ class Extension:
 
             if internal_callback_error:
                 return Status(overall_status_value, "\n".join(messages))
-
 
         # Handle regular statuses, merge all EndpointStatuses
         ep_status_merged = EndpointStatuses(0)

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -20,7 +20,7 @@ from typing import Any, ClassVar, NamedTuple
 
 from .activation import ActivationConfig, ActivationType
 from .callback import WrappedCallback
-from .communication import CommunicationClient, DebugClient, HttpClient, Status, StatusValue, MultiStatus, EndpointStatus, EndpointStatuses, EndpointSeverity, IgnoreStatus
+from .communication import CommunicationClient, DebugClient, HttpClient, Status, StatusValue, MultiStatus, EndpointStatus, EndpointStatuses, IgnoreStatus
 from .event import Severity
 from .metric import Metric, MetricType, SfmMetric, SummaryStat
 from .runtime import RuntimeProperties

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -1031,7 +1031,7 @@ class Extension:
         # Handle merged EndpointStatuses
         if ep_status_merged._num_endpoints > 0:
             ep_status_merged = ep_status_merged.build_common_status()
-            messages.append(ep_status_merged.message)
+            messages.insert(0, ep_status_merged.message)
             
             if ep_status_merged.is_warning():
                 any_warning = True

--- a/tests/sdk/test_status.py
+++ b/tests/sdk/test_status.py
@@ -3,9 +3,8 @@ import unittest
 from datetime import timedelta
 from unittest.mock import MagicMock
 
-from dynatrace_extension import Extension
+from dynatrace_extension import EndpointStatus, EndpointStatuses, Extension, Status, StatusValue
 from dynatrace_extension.sdk.communication import DebugClient, MultiStatus
-from dynatrace_extension.sdk.extension import EndpointStatus, EndpointStatuses, Status, StatusValue
 
 
 class TestStatus(unittest.TestCase):

--- a/tests/sdk/test_status.py
+++ b/tests/sdk/test_status.py
@@ -652,7 +652,7 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.GENERIC_ERROR)
-        self.assertIn("callback_multistatus: GENERIC_ERROR - MULTI MSG\nMethod=callback_status: EEC_CONNECTION_ERROR - STATUS MSG\nEndpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - UNKNOWN_ERROR EP MSG", status.message)
+        self.assertIn("callback_multistatus: GENERIC_ERROR - MULTI MSG\ncallback_status: EEC_CONNECTION_ERROR - STATUS MSG\nEndpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - UNKNOWN_ERROR EP MSG", status.message)
 
     def test_overall_status_ok(self):
         def callback_ep_status():
@@ -759,4 +759,4 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.WARNING)
-        self.assertIn("callback_multistatus: GENERIC_ERROR - \nMethod=callback_status: WARNING - \nEndpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - INVALID_CONFIG_ERROR", status.message)
+        self.assertIn("callback_multistatus: GENERIC_ERROR - \ncallback_status: WARNING - \nEndpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - INVALID_CONFIG_ERROR", status.message)

--- a/tests/sdk/test_status.py
+++ b/tests/sdk/test_status.py
@@ -4,9 +4,8 @@ from datetime import timedelta
 from unittest.mock import MagicMock
 
 from dynatrace_extension import Extension
-
 from dynatrace_extension.sdk.communication import DebugClient, MultiStatus
-from dynatrace_extension.sdk.extension import Status, StatusValue, EndpointStatuses, EndpointStatus
+from dynatrace_extension.sdk.extension import EndpointStatus, EndpointStatuses, Status, StatusValue
 
 
 class TestStatus(unittest.TestCase):
@@ -333,9 +332,10 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.WARNING)
-        self.assertIn("OK: 8 NOK: 2 NOK_reported_errors: 4.5.6.7:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme 2, 6.7.8.9:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme 3", status.message)
+        self.assertIn("OK: 8 NOK: 2 NOK_reported_errors: 4.5.6.7:80 - DEVICE_CONNECTION_ERROR "
+                      "Invalid authorization scheme 2, 6.7.8.9:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme 3", status.message)
 
-    
+
     def test_endpoint_status_all_faulty_endpoints(self):
         ext = Extension()
         ext.logger = MagicMock()
@@ -367,7 +367,9 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.GENERIC_ERROR)
-        self.assertIn("OK: 0 NOK: 3 NOK_reported_errors: 1.2.3.4:80 - AUTHENTICATION_ERROR Invalid authorization scheme 4, 4.5.6.7:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme 5, 6.7.8.9:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme 6", status.message)
+        self.assertIn("OK: 0 NOK: 3 NOK_reported_errors: 1.2.3.4:80 - AUTHENTICATION_ERROR "
+                      "Invalid authorization scheme 4, 4.5.6.7:80 - DEVICE_CONNECTION_ERROR "
+                      "Invalid authorization scheme 5, 6.7.8.9:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme 6", status.message)
 
 
     def test_endpoint_status_clearing_the_status(self):
@@ -383,7 +385,7 @@ class TestStatus(unittest.TestCase):
                 EndpointStatus("1.2.3.4:80",
                                StatusValue.AUTHENTICATION_ERROR,
                                "Invalid authorization scheme 7"))
-            
+
             statuses.add_endpoint_status(
                 EndpointStatus("4.5.6.7:80",
                                StatusValue.DEVICE_CONNECTION_ERROR,
@@ -393,12 +395,12 @@ class TestStatus(unittest.TestCase):
                 EndpointStatus("6.7.8.9:80",
                                StatusValue.DEVICE_CONNECTION_ERROR,
                                "Invalid authorization scheme 9"))
-                       
+
             statuses.add_endpoint_status(
                 EndpointStatus("4.5.6.7:80",
                                StatusValue.OK,
                                "Invalid authorization scheme 10"))
-            
+
             statuses.clear_endpoint_error("6.7.8.9:80")
 
             return statuses
@@ -425,13 +427,13 @@ class TestStatus(unittest.TestCase):
                 EndpointStatus("1.2.3.4:80",
                                StatusValue.AUTHENTICATION_ERROR,
                                "Invalid authorization scheme A"))
-            
+
             statuses.add_endpoint_status(
                 EndpointStatus("4.5.6.7:80",
                                StatusValue.DEVICE_CONNECTION_ERROR,
                                "Invalid authorization scheme B"))
 
-            with self.assertRaises(EndpointStatuses.TooManyEndpointStatuses):
+            with self.assertRaises(EndpointStatuses.TooManyEndpointStatusesError):
                 statuses.add_endpoint_status(
                     EndpointStatus("6.7.8.9:80",
                                    StatusValue.DEVICE_CONNECTION_ERROR,
@@ -444,7 +446,8 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.GENERIC_ERROR)
-        self.assertIn("OK: 0 NOK: 2 NOK_reported_errors: 1.2.3.4:80 - AUTHENTICATION_ERROR Invalid authorization scheme A, 4.5.6.7:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme B", status.message)
+        self.assertIn("OK: 0 NOK: 2 NOK_reported_errors: 1.2.3.4:80 - AUTHENTICATION_ERROR "
+                      "Invalid authorization scheme A, 4.5.6.7:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme B", status.message)
 
     def test_endpoint_empty(self):
         ext = Extension()
@@ -515,7 +518,7 @@ class TestStatus(unittest.TestCase):
         def callback_ep_status_1():
             status = EndpointStatuses(1)
             return status
-        
+
         def callback_ep_status_2():
             status = EndpointStatuses(2)
             return status
@@ -543,7 +546,7 @@ class TestStatus(unittest.TestCase):
                                StatusValue.AUTHENTICATION_ERROR,
                                "EP1 MSG"))
             return status
-        
+
         def callback_ep_status_2():
             status = EndpointStatuses(1)
             status.add_endpoint_status(
@@ -576,7 +579,7 @@ class TestStatus(unittest.TestCase):
                                StatusValue.OK,
                                "EP1 MSG"))
             return status
-        
+
         def callback_ep_status_2():
             status = EndpointStatuses(1)
             status.add_endpoint_status(
@@ -608,12 +611,12 @@ class TestStatus(unittest.TestCase):
                                StatusValue.UNKNOWN_ERROR,
                                "EP MSG"))
             return status
-        
+
         def callback_multistatus():
             status = MultiStatus()
             status.add_status(StatusValue.INVALID_ARGS_ERROR, "MULTI MSG")
             return status
-        
+
         def callback_status():
             status = Status(StatusValue.EEC_CONNECTION_ERROR, "STATUS MSG")
             return status
@@ -632,7 +635,8 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.GENERIC_ERROR)
-        self.assertIn("Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - UNKNOWN_ERROR EP MSG\ncallback_multistatus: GENERIC_ERROR - MULTI MSG\ncallback_status: EEC_CONNECTION_ERROR - STATUS MSG", status.message)
+        self.assertIn("Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - UNKNOWN_ERROR EP MSG"
+                      "\ncallback_multistatus: GENERIC_ERROR - MULTI MSG\ncallback_status: EEC_CONNECTION_ERROR - STATUS MSG", status.message)
 
     def test_overall_status_ok(self):
         def callback_ep_status():
@@ -642,12 +646,12 @@ class TestStatus(unittest.TestCase):
                                StatusValue.OK,
                                "EP MSG"))
             return status
-        
+
         def callback_multistatus():
             status = MultiStatus()
             status.add_status(StatusValue.OK, "")
             return status
-        
+
         def callback_status():
             status = Status(StatusValue.OK, "STATUS MSG")
             return status
@@ -677,12 +681,12 @@ class TestStatus(unittest.TestCase):
                                StatusValue.WARNING,
                                "EP MSG"))
             return status
-        
+
         def callback_multistatus():
             status = MultiStatus()
             status.add_status(StatusValue.OK, "MULTI MSG")
             return status
-        
+
         def callback_status():
             status = Status(StatusValue.OK, "")
             return status
@@ -712,12 +716,12 @@ class TestStatus(unittest.TestCase):
                                StatusValue.INVALID_CONFIG_ERROR,
                                ""))
             return status
-        
+
         def callback_multistatus():
             status = MultiStatus()
             status.add_status(StatusValue.INVALID_ARGS_ERROR, "")
             return status
-        
+
         def callback_status():
             status = Status(StatusValue.WARNING, "")
             return status
@@ -736,4 +740,5 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.WARNING)
-        self.assertIn("Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - INVALID_CONFIG_ERROR \ncallback_multistatus: GENERIC_ERROR - \ncallback_status: WARNING - ", status.message)
+        self.assertIn("Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - INVALID_CONFIG_ERROR "
+                      "\ncallback_multistatus: GENERIC_ERROR - \ncallback_status: WARNING - ", status.message)

--- a/tests/sdk/test_status.py
+++ b/tests/sdk/test_status.py
@@ -309,19 +309,14 @@ class TestStatus(unittest.TestCase):
 
         def callback():
             statuses = EndpointStatuses(10)
+            statuses.add_endpoint_status(EndpointStatus("1.2.3.4:80", StatusValue.OK, "Invalid authorization scheme 1"))
             statuses.add_endpoint_status(
-                EndpointStatus("1.2.3.4:80",
-                               StatusValue.OK,
-                               "Invalid authorization scheme 1"))
-            statuses.add_endpoint_status(
-                EndpointStatus("4.5.6.7:80",
-                               StatusValue.DEVICE_CONNECTION_ERROR,
-                               "Invalid authorization scheme 2"))
+                EndpointStatus("4.5.6.7:80", StatusValue.DEVICE_CONNECTION_ERROR, "Invalid authorization scheme 2")
+            )
 
             statuses.add_endpoint_status(
-                EndpointStatus("6.7.8.9:80",
-                               StatusValue.DEVICE_CONNECTION_ERROR,
-                               "Invalid authorization scheme 3"))
+                EndpointStatus("6.7.8.9:80", StatusValue.DEVICE_CONNECTION_ERROR, "Invalid authorization scheme 3")
+            )
 
             return statuses
 
@@ -331,9 +326,11 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.WARNING)
-        self.assertIn("OK: 8 NOK: 2 NOK_reported_errors: 4.5.6.7:80 - DEVICE_CONNECTION_ERROR "
-                      "Invalid authorization scheme 2, 6.7.8.9:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme 3", status.message)
-
+        self.assertIn(
+            "OK: 8 NOK: 2 NOK_reported_errors: 4.5.6.7:80 - DEVICE_CONNECTION_ERROR "
+            "Invalid authorization scheme 2, 6.7.8.9:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme 3",
+            status.message,
+        )
 
     def test_endpoint_status_all_faulty_endpoints(self):
         ext = Extension()
@@ -345,18 +342,15 @@ class TestStatus(unittest.TestCase):
         def callback():
             statuses = EndpointStatuses(3)
             statuses.add_endpoint_status(
-                EndpointStatus("1.2.3.4:80",
-                               StatusValue.AUTHENTICATION_ERROR,
-                               "Invalid authorization scheme 4"))
+                EndpointStatus("1.2.3.4:80", StatusValue.AUTHENTICATION_ERROR, "Invalid authorization scheme 4")
+            )
             statuses.add_endpoint_status(
-                EndpointStatus("4.5.6.7:80",
-                               StatusValue.DEVICE_CONNECTION_ERROR,
-                               "Invalid authorization scheme 5"))
+                EndpointStatus("4.5.6.7:80", StatusValue.DEVICE_CONNECTION_ERROR, "Invalid authorization scheme 5")
+            )
 
             statuses.add_endpoint_status(
-                EndpointStatus("6.7.8.9:80",
-                               StatusValue.DEVICE_CONNECTION_ERROR,
-                               "Invalid authorization scheme 6"))
+                EndpointStatus("6.7.8.9:80", StatusValue.DEVICE_CONNECTION_ERROR, "Invalid authorization scheme 6")
+            )
 
             return statuses
 
@@ -366,10 +360,12 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.GENERIC_ERROR)
-        self.assertIn("OK: 0 NOK: 3 NOK_reported_errors: 1.2.3.4:80 - AUTHENTICATION_ERROR "
-                      "Invalid authorization scheme 4, 4.5.6.7:80 - DEVICE_CONNECTION_ERROR "
-                      "Invalid authorization scheme 5, 6.7.8.9:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme 6", status.message)
-
+        self.assertIn(
+            "OK: 0 NOK: 3 NOK_reported_errors: 1.2.3.4:80 - AUTHENTICATION_ERROR "
+            "Invalid authorization scheme 4, 4.5.6.7:80 - DEVICE_CONNECTION_ERROR "
+            "Invalid authorization scheme 5, 6.7.8.9:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme 6",
+            status.message,
+        )
 
     def test_endpoint_status_clearing_the_status(self):
         ext = Extension()
@@ -381,24 +377,20 @@ class TestStatus(unittest.TestCase):
         def callback():
             statuses = EndpointStatuses(10)
             statuses.add_endpoint_status(
-                EndpointStatus("1.2.3.4:80",
-                               StatusValue.AUTHENTICATION_ERROR,
-                               "Invalid authorization scheme 7"))
+                EndpointStatus("1.2.3.4:80", StatusValue.AUTHENTICATION_ERROR, "Invalid authorization scheme 7")
+            )
 
             statuses.add_endpoint_status(
-                EndpointStatus("4.5.6.7:80",
-                               StatusValue.DEVICE_CONNECTION_ERROR,
-                               "Invalid authorization scheme 8"))
+                EndpointStatus("4.5.6.7:80", StatusValue.DEVICE_CONNECTION_ERROR, "Invalid authorization scheme 8")
+            )
 
             statuses.add_endpoint_status(
-                EndpointStatus("6.7.8.9:80",
-                               StatusValue.DEVICE_CONNECTION_ERROR,
-                               "Invalid authorization scheme 9"))
+                EndpointStatus("6.7.8.9:80", StatusValue.DEVICE_CONNECTION_ERROR, "Invalid authorization scheme 9")
+            )
 
             statuses.add_endpoint_status(
-                EndpointStatus("4.5.6.7:80",
-                               StatusValue.OK,
-                               "Invalid authorization scheme 10"))
+                EndpointStatus("4.5.6.7:80", StatusValue.OK, "Invalid authorization scheme 10")
+            )
 
             statuses.clear_endpoint_error("6.7.8.9:80")
 
@@ -410,8 +402,10 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.WARNING)
-        self.assertIn("OK: 9 NOK: 1 NOK_reported_errors: 1.2.3.4:80 - AUTHENTICATION_ERROR Invalid authorization scheme 7", status.message)
-
+        self.assertIn(
+            "OK: 9 NOK: 1 NOK_reported_errors: 1.2.3.4:80 - AUTHENTICATION_ERROR Invalid authorization scheme 7",
+            status.message,
+        )
 
     def test_endpoint_status_max(self):
         ext = Extension()
@@ -423,20 +417,17 @@ class TestStatus(unittest.TestCase):
         def callback():
             statuses = EndpointStatuses(2)
             statuses.add_endpoint_status(
-                EndpointStatus("1.2.3.4:80",
-                               StatusValue.AUTHENTICATION_ERROR,
-                               "Invalid authorization scheme A"))
+                EndpointStatus("1.2.3.4:80", StatusValue.AUTHENTICATION_ERROR, "Invalid authorization scheme A")
+            )
 
             statuses.add_endpoint_status(
-                EndpointStatus("4.5.6.7:80",
-                               StatusValue.DEVICE_CONNECTION_ERROR,
-                               "Invalid authorization scheme B"))
+                EndpointStatus("4.5.6.7:80", StatusValue.DEVICE_CONNECTION_ERROR, "Invalid authorization scheme B")
+            )
 
             with self.assertRaises(EndpointStatuses.TooManyEndpointStatusesError):
                 statuses.add_endpoint_status(
-                    EndpointStatus("6.7.8.9:80",
-                                   StatusValue.DEVICE_CONNECTION_ERROR,
-                                   "Invalid authorization scheme C"))
+                    EndpointStatus("6.7.8.9:80", StatusValue.DEVICE_CONNECTION_ERROR, "Invalid authorization scheme C")
+                )
             return statuses
 
         ext.schedule(callback, timedelta(seconds=1))
@@ -445,8 +436,11 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.GENERIC_ERROR)
-        self.assertIn("OK: 0 NOK: 2 NOK_reported_errors: 1.2.3.4:80 - AUTHENTICATION_ERROR "
-                      "Invalid authorization scheme A, 4.5.6.7:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme B", status.message)
+        self.assertIn(
+            "OK: 0 NOK: 2 NOK_reported_errors: 1.2.3.4:80 - AUTHENTICATION_ERROR "
+            "Invalid authorization scheme A, 4.5.6.7:80 - DEVICE_CONNECTION_ERROR Invalid authorization scheme B",
+            status.message,
+        )
 
     def test_endpoint_empty(self):
         ext = Extension()
@@ -477,9 +471,8 @@ class TestStatus(unittest.TestCase):
         def callback():
             statuses = EndpointStatuses(1)
             statuses.add_endpoint_status(
-                EndpointStatus("1.2.3.4:80",
-                               StatusValue.WARNING,
-                               "Invalid authorization scheme A"))
+                EndpointStatus("1.2.3.4:80", StatusValue.WARNING, "Invalid authorization scheme A")
+            )
             return statuses
 
         ext.schedule(callback, timedelta(seconds=1))
@@ -488,7 +481,9 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.WARNING)
-        self.assertIn("OK: 0 NOK: 1 NOK_reported_errors: 1.2.3.4:80 - WARNING Invalid authorization scheme A", status.message)
+        self.assertIn(
+            "OK: 0 NOK: 1 NOK_reported_errors: 1.2.3.4:80 - WARNING Invalid authorization scheme A", status.message
+        )
 
     def test_endpoint_status_single_error(self):
         ext = Extension()
@@ -500,9 +495,8 @@ class TestStatus(unittest.TestCase):
         def callback():
             statuses = EndpointStatuses(1)
             statuses.add_endpoint_status(
-                EndpointStatus("1.2.3.4:80",
-                               StatusValue.AUTHENTICATION_ERROR,
-                               "Invalid authorization scheme"))
+                EndpointStatus("1.2.3.4:80", StatusValue.AUTHENTICATION_ERROR, "Invalid authorization scheme")
+            )
             return statuses
 
         ext.schedule(callback, timedelta(seconds=1))
@@ -511,7 +505,10 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.GENERIC_ERROR)
-        self.assertIn("OK: 0 NOK: 1 NOK_reported_errors: 1.2.3.4:80 - AUTHENTICATION_ERROR Invalid authorization scheme", status.message)
+        self.assertIn(
+            "OK: 0 NOK: 1 NOK_reported_errors: 1.2.3.4:80 - AUTHENTICATION_ERROR Invalid authorization scheme",
+            status.message,
+        )
 
     def test_endpoint_merge_ok(self):
         def callback_ep_status_1():
@@ -540,18 +537,12 @@ class TestStatus(unittest.TestCase):
     def test_endpoint_merge_error(self):
         def callback_ep_status_1():
             status = EndpointStatuses(1)
-            status.add_endpoint_status(
-                EndpointStatus("EP_HINT_1",
-                               StatusValue.AUTHENTICATION_ERROR,
-                               "EP1 MSG"))
+            status.add_endpoint_status(EndpointStatus("EP_HINT_1", StatusValue.AUTHENTICATION_ERROR, "EP1 MSG"))
             return status
 
         def callback_ep_status_2():
             status = EndpointStatuses(1)
-            status.add_endpoint_status(
-                EndpointStatus("EP_HINT_2",
-                               StatusValue.INVALID_CONFIG_ERROR,
-                               "EP2 MSG"))
+            status.add_endpoint_status(EndpointStatus("EP_HINT_2", StatusValue.INVALID_CONFIG_ERROR, "EP2 MSG"))
             return status
 
         ext = Extension()
@@ -567,24 +558,20 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.GENERIC_ERROR)
-        self.assertIn("OK: 0 NOK: 2 NOK_reported_errors: EP_HINT_1 - AUTHENTICATION_ERROR EP1 MSG, EP_HINT_2 - INVALID_CONFIG_ERROR EP2 MSG", status.message)
-
+        self.assertIn(
+            "OK: 0 NOK: 2 NOK_reported_errors: EP_HINT_1 - AUTHENTICATION_ERROR EP1 MSG, EP_HINT_2 - INVALID_CONFIG_ERROR EP2 MSG",
+            status.message,
+        )
 
     def test_endpoint_merge_warning(self):
         def callback_ep_status_1():
             status = EndpointStatuses(1)
-            status.add_endpoint_status(
-                EndpointStatus("EP_HINT_1",
-                               StatusValue.OK,
-                               "EP1 MSG"))
+            status.add_endpoint_status(EndpointStatus("EP_HINT_1", StatusValue.OK, "EP1 MSG"))
             return status
 
         def callback_ep_status_2():
             status = EndpointStatuses(1)
-            status.add_endpoint_status(
-                EndpointStatus("EP_HINT_2",
-                               StatusValue.WARNING,
-                               "EP2 MSG"))
+            status.add_endpoint_status(EndpointStatus("EP_HINT_2", StatusValue.WARNING, "EP2 MSG"))
             return status
 
         ext = Extension()
@@ -605,10 +592,7 @@ class TestStatus(unittest.TestCase):
     def test_overall_status_error(self):
         def callback_ep_status():
             status = EndpointStatuses(1)
-            status.add_endpoint_status(
-                EndpointStatus("EP_HINT",
-                               StatusValue.UNKNOWN_ERROR,
-                               "EP MSG"))
+            status.add_endpoint_status(EndpointStatus("EP_HINT", StatusValue.UNKNOWN_ERROR, "EP MSG"))
             return status
 
         def callback_multistatus():
@@ -634,16 +618,16 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.GENERIC_ERROR)
-        self.assertIn("Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - UNKNOWN_ERROR EP MSG"
-                      "\ncallback_multistatus: GENERIC_ERROR - MULTI MSG\ncallback_status: EEC_CONNECTION_ERROR - STATUS MSG", status.message)
+        self.assertIn(
+            "Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - UNKNOWN_ERROR EP MSG"
+            "\ncallback_multistatus: GENERIC_ERROR - MULTI MSG\ncallback_status: EEC_CONNECTION_ERROR - STATUS MSG",
+            status.message,
+        )
 
     def test_overall_status_ok(self):
         def callback_ep_status():
             status = EndpointStatuses(1)
-            status.add_endpoint_status(
-                EndpointStatus("EP_HINT",
-                               StatusValue.OK,
-                               "EP MSG"))
+            status.add_endpoint_status(EndpointStatus("EP_HINT", StatusValue.OK, "EP MSG"))
             return status
 
         def callback_multistatus():
@@ -671,14 +655,10 @@ class TestStatus(unittest.TestCase):
         self.assertEqual(status.status, StatusValue.OK)
         self.assertIn("Endpoints OK: 1 NOK: 0\ncallback_status: OK - STATUS MSG", status.message)
 
-
     def test_overall_status_warning_1(self):
         def callback_ep_status():
             status = EndpointStatuses(1)
-            status.add_endpoint_status(
-                EndpointStatus("EP_HINT",
-                               StatusValue.WARNING,
-                               "EP MSG"))
+            status.add_endpoint_status(EndpointStatus("EP_HINT", StatusValue.WARNING, "EP MSG"))
             return status
 
         def callback_multistatus():
@@ -704,16 +684,15 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.WARNING)
-        self.assertIn("Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - WARNING EP MSG\ncallback_multistatus: OK - MULTI MSG", status.message)
-
+        self.assertIn(
+            "Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - WARNING EP MSG\ncallback_multistatus: OK - MULTI MSG",
+            status.message,
+        )
 
     def test_overall_status_warning_2(self):
         def callback_ep_status():
             status = EndpointStatuses(1)
-            status.add_endpoint_status(
-                EndpointStatus("EP_HINT",
-                               StatusValue.INVALID_CONFIG_ERROR,
-                               ""))
+            status.add_endpoint_status(EndpointStatus("EP_HINT", StatusValue.INVALID_CONFIG_ERROR, ""))
             return status
 
         def callback_multistatus():
@@ -739,5 +718,8 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.WARNING)
-        self.assertIn("Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - INVALID_CONFIG_ERROR "
-                      "\ncallback_multistatus: GENERIC_ERROR - \ncallback_status: WARNING - ", status.message)
+        self.assertIn(
+            "Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - INVALID_CONFIG_ERROR "
+            "\ncallback_multistatus: GENERIC_ERROR - \ncallback_status: WARNING - ",
+            status.message,
+        )

--- a/tests/sdk/test_status.py
+++ b/tests/sdk/test_status.py
@@ -632,7 +632,7 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.GENERIC_ERROR)
-        self.assertIn("callback_multistatus: GENERIC_ERROR - MULTI MSG\ncallback_status: EEC_CONNECTION_ERROR - STATUS MSG\nEndpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - UNKNOWN_ERROR EP MSG", status.message)
+        self.assertIn("Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - UNKNOWN_ERROR EP MSG\ncallback_multistatus: GENERIC_ERROR - MULTI MSG\ncallback_status: EEC_CONNECTION_ERROR - STATUS MSG", status.message)
 
     def test_overall_status_ok(self):
         def callback_ep_status():
@@ -666,7 +666,7 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.OK)
-        self.assertIn("callback_status: OK - STATUS MSG\nEndpoints OK: 1 NOK: 0", status.message)
+        self.assertIn("Endpoints OK: 1 NOK: 0\ncallback_status: OK - STATUS MSG", status.message)
 
 
     def test_overall_status_warning_1(self):
@@ -701,7 +701,7 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.WARNING)
-        self.assertIn("callback_multistatus: OK - MULTI MSG\nEndpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - WARNING EP MSG", status.message)
+        self.assertIn("Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - WARNING EP MSG\ncallback_multistatus: OK - MULTI MSG", status.message)
 
 
     def test_overall_status_warning_2(self):
@@ -736,4 +736,4 @@ class TestStatus(unittest.TestCase):
 
         status = ext._build_current_status()
         self.assertEqual(status.status, StatusValue.WARNING)
-        self.assertIn("callback_multistatus: GENERIC_ERROR - \ncallback_status: WARNING - \nEndpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - INVALID_CONFIG_ERROR", status.message)
+        self.assertIn("Endpoints OK: 0 NOK: 1 NOK_reported_errors: EP_HINT - INVALID_CONFIG_ERROR \ncallback_multistatus: GENERIC_ERROR - \ncallback_status: WARNING - ", status.message)

--- a/tests/sdk/test_status.py
+++ b/tests/sdk/test_status.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 from dynatrace_extension import Extension
 
 from dynatrace_extension.sdk.communication import DebugClient, MultiStatus
-from dynatrace_extension.sdk.extension import Status, StatusValue, EndpointStatuses, EndpointStatus, EndpointSeverity
+from dynatrace_extension.sdk.extension import Status, StatusValue, EndpointStatuses, EndpointStatus
 
 
 class TestStatus(unittest.TestCase):
@@ -313,18 +313,15 @@ class TestStatus(unittest.TestCase):
             statuses = EndpointStatuses(10)
             statuses.add_endpoint_status(
                 EndpointStatus("1.2.3.4:80",
-                               EndpointSeverity.INFO,
                                StatusValue.OK,
                                "Invalid authorization scheme 1"))
             statuses.add_endpoint_status(
                 EndpointStatus("4.5.6.7:80",
-                               EndpointSeverity.ERROR,
                                StatusValue.DEVICE_CONNECTION_ERROR,
                                "Invalid authorization scheme 2"))
 
             statuses.add_endpoint_status(
                 EndpointStatus("6.7.8.9:80",
-                               EndpointSeverity.WARNING,
                                StatusValue.DEVICE_CONNECTION_ERROR,
                                "Invalid authorization scheme 3"))
 
@@ -350,18 +347,15 @@ class TestStatus(unittest.TestCase):
             statuses = EndpointStatuses(3)
             statuses.add_endpoint_status(
                 EndpointStatus("1.2.3.4:80",
-                               EndpointSeverity.INFO,
                                StatusValue.AUTHENTICATION_ERROR,
                                "Invalid authorization scheme 4"))
             statuses.add_endpoint_status(
                 EndpointStatus("4.5.6.7:80",
-                               EndpointSeverity.ERROR,
                                StatusValue.DEVICE_CONNECTION_ERROR,
                                "Invalid authorization scheme 5"))
 
             statuses.add_endpoint_status(
                 EndpointStatus("6.7.8.9:80",
-                               EndpointSeverity.WARNING,
                                StatusValue.DEVICE_CONNECTION_ERROR,
                                "Invalid authorization scheme 6"))
 
@@ -387,25 +381,21 @@ class TestStatus(unittest.TestCase):
             statuses = EndpointStatuses(10)
             statuses.add_endpoint_status(
                 EndpointStatus("1.2.3.4:80",
-                               EndpointSeverity.INFO,
                                StatusValue.AUTHENTICATION_ERROR,
                                "Invalid authorization scheme 7"))
             
             statuses.add_endpoint_status(
                 EndpointStatus("4.5.6.7:80",
-                               EndpointSeverity.WARNING,
                                StatusValue.DEVICE_CONNECTION_ERROR,
                                "Invalid authorization scheme 8"))
 
             statuses.add_endpoint_status(
                 EndpointStatus("6.7.8.9:80",
-                               EndpointSeverity.ERROR,
                                StatusValue.DEVICE_CONNECTION_ERROR,
                                "Invalid authorization scheme 9"))
                        
             statuses.add_endpoint_status(
                 EndpointStatus("4.5.6.7:80",
-                               EndpointSeverity.ERROR,
                                StatusValue.OK,
                                "Invalid authorization scheme 10"))
             
@@ -433,20 +423,17 @@ class TestStatus(unittest.TestCase):
             statuses = EndpointStatuses(2)
             statuses.add_endpoint_status(
                 EndpointStatus("1.2.3.4:80",
-                               EndpointSeverity.INFO,
                                StatusValue.AUTHENTICATION_ERROR,
                                "Invalid authorization scheme A"))
             
             statuses.add_endpoint_status(
                 EndpointStatus("4.5.6.7:80",
-                               EndpointSeverity.WARNING,
                                StatusValue.DEVICE_CONNECTION_ERROR,
                                "Invalid authorization scheme B"))
 
             with self.assertRaises(EndpointStatuses.TooManyEndpointStatuses):
                 statuses.add_endpoint_status(
                     EndpointStatus("6.7.8.9:80",
-                                   EndpointSeverity.ERROR,
                                    StatusValue.DEVICE_CONNECTION_ERROR,
                                    "Invalid authorization scheme C"))
             return statuses
@@ -489,7 +476,6 @@ class TestStatus(unittest.TestCase):
             statuses = EndpointStatuses(1)
             statuses.add_endpoint_status(
                 EndpointStatus("1.2.3.4:80",
-                               EndpointSeverity.INFO,
                                StatusValue.WARNING,
                                "Invalid authorization scheme A"))
             return statuses
@@ -513,7 +499,6 @@ class TestStatus(unittest.TestCase):
             statuses = EndpointStatuses(1)
             statuses.add_endpoint_status(
                 EndpointStatus("1.2.3.4:80",
-                               EndpointSeverity.INFO,
                                StatusValue.AUTHENTICATION_ERROR,
                                "Invalid authorization scheme"))
             return statuses
@@ -555,7 +540,6 @@ class TestStatus(unittest.TestCase):
             status = EndpointStatuses(1)
             status.add_endpoint_status(
                 EndpointStatus("EP_HINT_1",
-                               EndpointSeverity.INFO,
                                StatusValue.AUTHENTICATION_ERROR,
                                "EP1 MSG"))
             return status
@@ -564,7 +548,6 @@ class TestStatus(unittest.TestCase):
             status = EndpointStatuses(1)
             status.add_endpoint_status(
                 EndpointStatus("EP_HINT_2",
-                               EndpointSeverity.INFO,
                                StatusValue.INVALID_CONFIG_ERROR,
                                "EP2 MSG"))
             return status
@@ -590,7 +573,6 @@ class TestStatus(unittest.TestCase):
             status = EndpointStatuses(1)
             status.add_endpoint_status(
                 EndpointStatus("EP_HINT_1",
-                               EndpointSeverity.INFO,
                                StatusValue.OK,
                                "EP1 MSG"))
             return status
@@ -599,7 +581,6 @@ class TestStatus(unittest.TestCase):
             status = EndpointStatuses(1)
             status.add_endpoint_status(
                 EndpointStatus("EP_HINT_2",
-                               EndpointSeverity.INFO,
                                StatusValue.WARNING,
                                "EP2 MSG"))
             return status
@@ -624,7 +605,6 @@ class TestStatus(unittest.TestCase):
             status = EndpointStatuses(1)
             status.add_endpoint_status(
                 EndpointStatus("EP_HINT",
-                               EndpointSeverity.INFO,
                                StatusValue.UNKNOWN_ERROR,
                                "EP MSG"))
             return status
@@ -659,7 +639,6 @@ class TestStatus(unittest.TestCase):
             status = EndpointStatuses(1)
             status.add_endpoint_status(
                 EndpointStatus("EP_HINT",
-                               EndpointSeverity.INFO,
                                StatusValue.OK,
                                "EP MSG"))
             return status
@@ -695,7 +674,6 @@ class TestStatus(unittest.TestCase):
             status = EndpointStatuses(1)
             status.add_endpoint_status(
                 EndpointStatus("EP_HINT",
-                               EndpointSeverity.INFO,
                                StatusValue.WARNING,
                                "EP MSG"))
             return status
@@ -731,7 +709,6 @@ class TestStatus(unittest.TestCase):
             status = EndpointStatuses(1)
             status.add_endpoint_status(
                 EndpointStatus("EP_HINT",
-                               EndpointSeverity.INFO,
                                StatusValue.INVALID_CONFIG_ERROR,
                                ""))
             return status


### PR DESCRIPTION
* implementation of `EndpointStatuses`
* introduction of `Warning` status
* new rules of building overall status:
  * `OK` only if all partial statuses are `OK`
  * `GENERIC_ERROR` only if all partial statuses are `ERROR-like`
  * `WARNING` if both `OK` and `ERROR-like` statuses are present, or single `WARNING` is present - in general `WARNING` means that some statuses are OK and some failed
* UT


