### PR TITLE
Feature/sfm logs per endpoint

### DIFF
--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.6.3"
+__version__ = "1.7.0"

--- a/dynatrace_extension/sdk/communication.py
+++ b/dynatrace_extension/sdk/communication.py
@@ -129,7 +129,7 @@ class EndpointStatus:
         self.status: StatusValue = short_status
         self.message = message
 
-    def __str__(self):
+    def __repr__(self):
         return str(self.__dict__)
     
     def __eq__(self, other):

--- a/dynatrace_extension/sdk/communication.py
+++ b/dynatrace_extension/sdk/communication.py
@@ -131,6 +131,10 @@ class EndpointStatus:
 
     def __str__(self):
         return str(self.__dict__)
+    
+    def __eq__(self, other):
+        return isinstance(other, EndpointStatus) and self.__dict__ == other.__dict__
+
 
 
 class EndpointStatuses:
@@ -140,7 +144,6 @@ class EndpointStatuses:
 
     def __init__(self, total_endpoints_number=None):
         if total_endpoints_number is not None:
-            # TODO: DeprecationWarning or a custom exception?
             raise DeprecationWarning("EndpointStatuses::__init__: usage of `total_endpoints_number` parameter is abandoned. Use other class methods to explicitly report all status changes for any endpoint.")
         
         self._lock = Lock()
@@ -431,8 +434,7 @@ class HttpClient(CommunicationClient):
 
     def send_sfm_logs(self, sfm_logs: dict | list[dict]):
         self.logger.debug(f"Sending SFM logs: {sfm_logs}")
-        # TODO: eec_enrichment?
-        return self._send_events(self._sfm_logs_url, sfm_logs, eec_enrichment=True)
+        return self._send_events(self._sfm_logs_url, sfm_logs)
     
     def _send_events(self, url, events: dict | list[dict], eec_enrichment: bool = True) -> list[dict | None]:
         responses = []

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -1038,7 +1038,7 @@ class Extension:
                 return Status(overall_status_value, "\n".join(messages))
 
         # Handle regular statuses, merge all EndpointStatuses
-        ep_status_merged = EndpointStatuses(0)
+        ep_status_merged = EndpointStatuses()
         all_ok = True
         all_err = True
         any_warning = False
@@ -1066,7 +1066,7 @@ class Extension:
                 messages.append(f"{callback.name()}: {callback.status.status.value} - {callback.status.message}")
 
         # Handle merged EndpointStatuses
-        if ep_status_merged._num_endpoints > 0:
+        if ep_status_merged.contains_any_status():
             ep_status_merged = ep_status_merged.build_common_status()
             messages.insert(0, ep_status_merged.message)
 

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -1221,3 +1221,25 @@ class Extension:
                 raise FileNotFoundError(msg)
 
         return Snapshot.parse_from_file(snapshot_file)
+
+    def _send_sfm_logs(self, logs: dict | list[dict]):
+        # TODO: build some async sender similar to events and sfm metrics?
+        self._client.send_sfm_logs(logs)
+
+    def _send_ep_status_log(self, endpoint_name: str, prefix: str, status_value: StatusValue, status_message: str):
+        # TODO: dont send/enqueue each logs separately?
+        level = Severity.ERROR.value
+        
+        if status_value == StatusValue.OK:  # TODO: what about other nonerror statuses?
+            level = Severity.INFO.value
+        elif status_value == StatusValue.WARNING:
+            level = Severity.WARN.value
+
+        ep_status_log = {
+            "device.address": endpoint_name,
+            "level": level,
+            "message": f"{endpoint_name}: {prefix} - {status_message}",
+            **self._metadata
+        }
+
+        self._send_sfm_logs(ep_status_log)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dependencies = [
     "pytest",
     "typer[all]",
     "pyyaml",
-    "dt-cli>=1.6.13"
+    "dt-cli>=1.6.13",
+    "freezegun"
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/tests/sdk/test_endpoints_sfm.py
+++ b/tests/sdk/test_endpoints_sfm.py
@@ -1,14 +1,15 @@
+import threading
 import time
 import unittest
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock
-import threading
+
 from freezegun import freeze_time
 
-from dynatrace_extension import EndpointStatus, EndpointStatuses, Extension, StatusValue, Severity
+from dynatrace_extension import EndpointStatus, EndpointStatuses, Extension, Severity, StatusValue
 
 
-class KillScheduler(Exception):
+class KillSchedulerError(Exception):
     pass
 
 class TestSfmPerEndpont(unittest.TestCase):
@@ -21,22 +22,22 @@ class TestSfmPerEndpont(unittest.TestCase):
         self.i = 0
         self.test_cases = None
         self.time_machine_idx = None
-        
-        self.ext.schedule(self.callback, timedelta(seconds=1))
-        self.scheduler_thread = threading.Thread(target=self.schedulerThreadFun)
 
-    def schedulerThreadFun(self):
-        with self.assertRaises(KillScheduler):
+        self.ext.schedule(self.callback, timedelta(seconds=1))
+        self.scheduler_thread = threading.Thread(target=self.scheduler_thread_fun)
+
+    def scheduler_thread_fun(self):
+        with self.assertRaises(KillSchedulerError):
             self.ext._scheduler.run()
 
     def tearDown(self) -> None:
-        self.ext._scheduler.enter(delay=0, priority=1, action=lambda: (_ for _ in ()).throw(KillScheduler()))
+        self.ext._scheduler.enter(delay=0, priority=1, action=lambda: (_ for _ in ()).throw(KillSchedulerError()))
         self.scheduler_thread.join()
         Extension._instance = None
 
-    def runTest(self):
+    def run_test(self):
         self.scheduler_thread.start()
-        time.sleep(0.1)        
+        time.sleep(0.1)
 
         for case in self.test_cases[:self.time_machine_idx]:
             self.single_test_iteration(case)
@@ -44,14 +45,13 @@ class TestSfmPerEndpont(unittest.TestCase):
         if self.time_machine_idx:
             with freeze_time(datetime.now() + timedelta(hours=2), tick=True):
                 for case in self.test_cases[self.time_machine_idx:]:
-                    self.single_test_iteration(case)        
+                    self.single_test_iteration(case)
 
     def single_test_iteration(self, case):
-        print(f"Test case: {case}")
         self.ext._client.send_sfm_logs.reset_mock()
         self.ext._build_current_status()
         time.sleep(0.05) # sleep required becuase mocked method is called in a different thread
-        
+
         if case["expected"]:
             if not isinstance(case["expected"], list):
                 case["expected"] = [case["expected"]]
@@ -72,37 +72,71 @@ class TestSfmPerEndpont(unittest.TestCase):
 
         return ep_status
 
+    def expected_sfm_dict(self, device_address, level, status, status_msg, status_state,
+        dt_extension_config_id="", dt_extension_ds="python", dt_extension_version ="",
+        dt_extension_name="", dt_extension_config_label=""):
+
+        return {
+            "device.address": device_address,
+            "level": level,
+            "message": f"{device_address}: [{status_state}] - {status} {status_msg}",
+            "dt.extension.config.id": dt_extension_config_id,
+            "dt.extension.ds": dt_extension_ds,
+            "dt.extension.version": dt_extension_version,
+            "dt.extension.name": dt_extension_name,
+            "dt.extension.config.label": dt_extension_config_label
+        }
+
     def test_endpoint_sfm_ok(self):
         self.time_machine_idx = 5
         self.test_cases = [
-            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 1"), "expected": None},   # Initial OK status
-            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 1"), "expected": None},   # Same OK status reported
-            {"status": None,                                                       "expected": None},   # Nothing reported
-            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 2"), "expected": {'device.address': '1.2.3.4:80', 'level': 'INFO', 'message': '1.2.3.4:80: [NEW] - OK All good 2'}},   # New OK status
-            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 2"), "expected": None},   # Same OK status reported
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 1"), "expected": None},
+
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 1"), "expected": None},
+
+            {"status": None, "expected": None},
+
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 2"),
+             "expected": self.expected_sfm_dict(device_address="1.2.3.4:80", level="INFO", status="OK", status_msg="All good 2", status_state="NEW")},
+
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 2"), "expected": None},
+
             # Time machine applied
-            {"status": None,                                                       "expected": None},   # Check if ONGOING skipped (+2h ahead)
-            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 3"), "expected": {'device.address': '1.2.3.4:80', 'level': 'INFO', 'message': '1.2.3.4:80: [NEW] - OK All good 3'}}   # New OK status
+            {"status": None, "expected": None},
+
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 3"),
+             "expected": self.expected_sfm_dict(device_address="1.2.3.4:80", level="INFO", status="OK", status_msg="All good 3", status_state="NEW")}
         ]
-        
-        self.runTest()
+
+        self.run_test()
 
     def test_endpoint_sfm_nok(self):
         self.time_machine_idx = 2
         self.test_cases = [
-            {"status": EndpointStatus("1.2.3.4:80", StatusValue.WARNING, "Warning 1"), "expected": {'device.address': '1.2.3.4:80', 'level': 'WARN', 'message': '1.2.3.4:80: [INITIAL] - WARNING Warning 1'}},
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.WARNING, "Warning 1"),
+             "expected": self.expected_sfm_dict(device_address="1.2.3.4:80", level="WARN", status="WARNING", status_msg="Warning 1", status_state="INITIAL")},
+
             {"status": EndpointStatus("1.2.3.4:80", StatusValue.WARNING, "Warning 1"), "expected": None},
+
             # Time machine applied
-            {"status": None, "expected": {'device.address': '1.2.3.4:80', 'level': 'WARN', 'message': '1.2.3.4:80: [ONGOING] - WARNING Warning 1'}},
-            {"status": EndpointStatus("1.2.3.4:80", StatusValue.GENERIC_ERROR, "Generic error 1"), "expected": {'device.address': '1.2.3.4:80', 'level': 'ERROR', 'message': '1.2.3.4:80: [NEW] - GENERIC_ERROR Generic error 1'}},
-            {"status": EndpointStatus("1.2.3.4:80", StatusValue.WARNING, "Warning 1"), "expected": {'device.address': '1.2.3.4:80', 'level': 'WARN', 'message': '1.2.3.4:80: [NEW] - WARNING Warning 1'}},
-            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 1"), "expected": {'device.address': '1.2.3.4:80', 'level': 'INFO', 'message': '1.2.3.4:80: [NEW] - OK All good 1'}}
+            {"status": None,
+             "expected": self.expected_sfm_dict(device_address="1.2.3.4:80", level="WARN", status="WARNING", status_msg="Warning 1", status_state="ONGOING")},
+
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.GENERIC_ERROR, "Generic error 1"),
+             "expected": self.expected_sfm_dict(device_address="1.2.3.4:80", level="ERROR", status="GENERIC_ERROR", status_msg="Generic error 1",
+                                              status_state="NEW")},
+
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.WARNING, "Warning 1"),
+             "expected": self.expected_sfm_dict(device_address="1.2.3.4:80", level="WARN", status="WARNING", status_msg="Warning 1", status_state="NEW")},
+
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 1"),
+             "expected": self.expected_sfm_dict(device_address="1.2.3.4:80", level="INFO", status="OK", status_msg="All good 1", status_state="NEW")}
         ]
-        
-        self.runTest()
+
+        self.run_test()
 
     def test_endpoint_sfm_severity(self):
-        def expectedSevertity(status: StatusValue):
+        def expected_severtity(status: StatusValue):
             requirements = {
                 StatusValue.EMPTY: Severity.INFO,
                 StatusValue.OK: Severity.INFO,
@@ -122,10 +156,13 @@ class TestSfmPerEndpont(unittest.TestCase):
             return requirements[status].value
 
         self.test_cases = [
-            {"status": EndpointStatus(f"1.2.3.4:123", status, f"Status {i}"), "expected": {'device.address': f'1.2.3.4:123', 'level': f'{expectedSevertity(status)}', 'message': f'1.2.3.4:123: [{"INITIAL" if i == 0 else "NEW"}] - {status.value} Status {i}'}} for i, status in enumerate(StatusValue)
+            {"status": EndpointStatus("1.2.3.4:123", status, f"Status {i}"),
+             "expected": self.expected_sfm_dict(device_address="1.2.3.4:123", level=expected_severtity(status), status=status.value, status_msg=f"Status {i}",
+                                              status_state="INITIAL" if i == 0 else "NEW")
+        } for i, status in enumerate(StatusValue)
         ]
 
-        self.runTest()
+        self.run_test()
 
     def test_endpoint_custom_blocked(self):
         self.ext = None
@@ -134,18 +171,29 @@ class TestSfmPerEndpont(unittest.TestCase):
         self.test_cases = [
             {"status": EndpointStatus("1.2.3.4:80", StatusValue.GENERIC_ERROR, "Generic error 1"), "expected": None}
         ]
-        
-        self.runTest()
+
+        self.run_test()
 
     def test_endpoint_independent_ongoing(self):
         self.test_cases = [
-            {"status": EndpointStatus("1.2.3.4:1", StatusValue.WARNING, "Warning 1"), "expected": {'device.address': '1.2.3.4:1', 'level': 'WARN', 'message': '1.2.3.4:1: [INITIAL] - WARNING Warning 1'}},
-            {"status": EndpointStatus("1.2.3.4:2", StatusValue.WARNING, "Warning 2"), "expected": {'device.address': '1.2.3.4:2', 'level': 'WARN', 'message': '1.2.3.4:2: [INITIAL] - WARNING Warning 2'}},
-            {"status": EndpointStatus("1.2.3.4:1", StatusValue.WARNING, "Warning 1"), "expected": {'device.address': '1.2.3.4:1', 'level': 'WARN', 'message': '1.2.3.4:1: [ONGOING] - WARNING Warning 1'}},
-            {"status": EndpointStatus("1.2.3.4:2", StatusValue.WARNING, "Warning 2"), "expected": {'device.address': '1.2.3.4:2', 'level': 'WARN', 'message': '1.2.3.4:2: [ONGOING] - WARNING Warning 2'}},
-            {"status": None, "expected": [{'device.address': '1.2.3.4:1', 'level': 'WARN', 'message': '1.2.3.4:1: [ONGOING] - WARNING Warning 1'}, {'device.address': '1.2.3.4:2', 'level': 'WARN', 'message': '1.2.3.4:2: [ONGOING] - WARNING Warning 2'}]}
+            {"status": EndpointStatus("1.2.3.4:1", StatusValue.WARNING, "Warning 1"),
+             "expected": self.expected_sfm_dict(device_address="1.2.3.4:1", level="WARN", status="WARNING", status_msg="Warning 1", status_state="INITIAL")},
+
+            {"status": EndpointStatus("1.2.3.4:2", StatusValue.WARNING, "Warning 2"),
+             "expected": self.expected_sfm_dict(device_address="1.2.3.4:2", level="WARN", status="WARNING", status_msg="Warning 2", status_state="INITIAL")},
+
+            {"status": EndpointStatus("1.2.3.4:1", StatusValue.WARNING, "Warning 1"),
+             "expected": self.expected_sfm_dict(device_address="1.2.3.4:1", level="WARN", status="WARNING", status_msg="Warning 1", status_state="ONGOING")},
+
+            {"status": EndpointStatus("1.2.3.4:2", StatusValue.WARNING, "Warning 2"),
+             "expected": self.expected_sfm_dict(device_address="1.2.3.4:2", level="WARN", status="WARNING", status_msg="Warning 2", status_state="ONGOING")},
+
+            {"status": None, "expected": [
+                self.expected_sfm_dict(device_address="1.2.3.4:1", level="WARN", status="WARNING", status_msg="Warning 1", status_state="ONGOING"),
+                self.expected_sfm_dict(device_address="1.2.3.4:2", level="WARN", status="WARNING", status_msg="Warning 2", status_state="ONGOING")]
+            }
         ]
-        
+
         self.scheduler_thread.start()
         time.sleep(0.1)
 

--- a/tests/sdk/test_endpoints_sfm.py
+++ b/tests/sdk/test_endpoints_sfm.py
@@ -1,0 +1,164 @@
+import time
+import unittest
+from datetime import timedelta, datetime
+from unittest.mock import MagicMock
+import threading
+from freezegun import freeze_time
+
+from dynatrace_extension import EndpointStatus, EndpointStatuses, Extension, StatusValue, Severity
+
+
+class KillScheduler(Exception):
+    pass
+
+class TestSfmPerEndpont(unittest.TestCase):
+    def setUp(self, extension_name=""):
+        self.ext = Extension(name=extension_name)
+        self.ext.logger = MagicMock()
+        self.ext._running_in_sim = True
+        self.ext._client = MagicMock()
+        self.ext._is_fastcheck = False
+        self.i = 0
+        self.test_cases = None
+        self.time_machine_idx = None
+        
+        self.ext.schedule(self.callback, timedelta(seconds=1))
+        self.scheduler_thread = threading.Thread(target=self.schedulerThreadFun)
+
+    def schedulerThreadFun(self):
+        with self.assertRaises(KillScheduler):
+            self.ext._scheduler.run()
+
+    def tearDown(self) -> None:
+        self.ext._scheduler.enter(delay=0, priority=1, action=lambda: (_ for _ in ()).throw(KillScheduler()))
+        self.scheduler_thread.join()
+        Extension._instance = None
+
+    def runTest(self):
+        self.scheduler_thread.start()
+        time.sleep(0.1)        
+
+        for case in self.test_cases[:self.time_machine_idx]:
+            self.single_test_iteration(case)
+
+        if self.time_machine_idx:
+            with freeze_time(datetime.now() + timedelta(hours=2), tick=True):
+                for case in self.test_cases[self.time_machine_idx:]:
+                    self.single_test_iteration(case)        
+
+    def single_test_iteration(self, case):
+        print(f"Test case: {case}")
+        self.ext._client.send_sfm_logs.reset_mock()
+        self.ext._build_current_status()
+        time.sleep(0.05) # sleep required becuase mocked method is called in a different thread
+        
+        if case["expected"]:
+            if not isinstance(case["expected"], list):
+                case["expected"] = [case["expected"]]
+            self.ext._client.send_sfm_logs.assert_called_once_with(case["expected"])
+        else:
+            self.ext._client.send_sfm_logs.assert_not_called()
+
+        time.sleep(1)
+
+    def callback(self):
+        assert self.test_cases
+
+        ep_status = EndpointStatuses()
+        if self.i < len(self.test_cases):
+            if self.test_cases[self.i]["status"]:
+                ep_status.add_endpoint_status(self.test_cases[self.i]["status"])
+            self.i += 1
+
+        return ep_status
+
+    def test_endpoint_sfm_ok(self):
+        self.time_machine_idx = 5
+        self.test_cases = [
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 1"), "expected": None},   # Initial OK status
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 1"), "expected": None},   # Same OK status reported
+            {"status": None,                                                       "expected": None},   # Nothing reported
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 2"), "expected": {'device.address': '1.2.3.4:80', 'level': 'INFO', 'message': '1.2.3.4:80: [NEW] - OK All good 2'}},   # New OK status
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 2"), "expected": None},   # Same OK status reported
+            # Time machine applied
+            {"status": None,                                                       "expected": None},   # Check if ONGOING skipped (+2h ahead)
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 3"), "expected": {'device.address': '1.2.3.4:80', 'level': 'INFO', 'message': '1.2.3.4:80: [NEW] - OK All good 3'}}   # New OK status
+        ]
+        
+        self.runTest()
+
+    def test_endpoint_sfm_nok(self):
+        self.time_machine_idx = 2
+        self.test_cases = [
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.WARNING, "Warning 1"), "expected": {'device.address': '1.2.3.4:80', 'level': 'WARN', 'message': '1.2.3.4:80: [INITIAL] - WARNING Warning 1'}},
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.WARNING, "Warning 1"), "expected": None},
+            # Time machine applied
+            {"status": None, "expected": {'device.address': '1.2.3.4:80', 'level': 'WARN', 'message': '1.2.3.4:80: [ONGOING] - WARNING Warning 1'}},
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.GENERIC_ERROR, "Generic error 1"), "expected": {'device.address': '1.2.3.4:80', 'level': 'ERROR', 'message': '1.2.3.4:80: [NEW] - GENERIC_ERROR Generic error 1'}},
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.WARNING, "Warning 1"), "expected": {'device.address': '1.2.3.4:80', 'level': 'WARN', 'message': '1.2.3.4:80: [NEW] - WARNING Warning 1'}},
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.OK, "All good 1"), "expected": {'device.address': '1.2.3.4:80', 'level': 'INFO', 'message': '1.2.3.4:80: [NEW] - OK All good 1'}}
+        ]
+        
+        self.runTest()
+
+    def test_endpoint_sfm_severity(self):
+        def expectedSevertity(status: StatusValue):
+            requirements = {
+                StatusValue.EMPTY: Severity.INFO,
+                StatusValue.OK: Severity.INFO,
+                StatusValue.GENERIC_ERROR: Severity.ERROR,
+                StatusValue.INVALID_ARGS_ERROR: Severity.ERROR,
+                StatusValue.EEC_CONNECTION_ERROR: Severity.ERROR,
+                StatusValue.INVALID_CONFIG_ERROR: Severity.ERROR,
+                StatusValue.AUTHENTICATION_ERROR: Severity.ERROR,
+                StatusValue.DEVICE_CONNECTION_ERROR: Severity.ERROR,
+                StatusValue.WARNING: Severity.WARN,
+                StatusValue.UNKNOWN_ERROR: Severity.ERROR
+            }
+
+            for s in StatusValue:
+                assert s in requirements.keys()
+
+            return requirements[status].value
+
+        self.test_cases = [
+            {"status": EndpointStatus(f"1.2.3.4:123", status, f"Status {i}"), "expected": {'device.address': f'1.2.3.4:123', 'level': f'{expectedSevertity(status)}', 'message': f'1.2.3.4:123: [{"INITIAL" if i == 0 else "NEW"}] - {status.value} Status {i}'}} for i, status in enumerate(StatusValue)
+        ]
+
+        self.runTest()
+
+    def test_endpoint_custom_blocked(self):
+        self.ext = None
+        Extension._instance = None
+        self.setUp(extension_name="custom:custom_ext_unit_test")
+        self.test_cases = [
+            {"status": EndpointStatus("1.2.3.4:80", StatusValue.GENERIC_ERROR, "Generic error 1"), "expected": None}
+        ]
+        
+        self.runTest()
+
+    def test_endpoint_independent_ongoing(self):
+        self.test_cases = [
+            {"status": EndpointStatus("1.2.3.4:1", StatusValue.WARNING, "Warning 1"), "expected": {'device.address': '1.2.3.4:1', 'level': 'WARN', 'message': '1.2.3.4:1: [INITIAL] - WARNING Warning 1'}},
+            {"status": EndpointStatus("1.2.3.4:2", StatusValue.WARNING, "Warning 2"), "expected": {'device.address': '1.2.3.4:2', 'level': 'WARN', 'message': '1.2.3.4:2: [INITIAL] - WARNING Warning 2'}},
+            {"status": EndpointStatus("1.2.3.4:1", StatusValue.WARNING, "Warning 1"), "expected": {'device.address': '1.2.3.4:1', 'level': 'WARN', 'message': '1.2.3.4:1: [ONGOING] - WARNING Warning 1'}},
+            {"status": EndpointStatus("1.2.3.4:2", StatusValue.WARNING, "Warning 2"), "expected": {'device.address': '1.2.3.4:2', 'level': 'WARN', 'message': '1.2.3.4:2: [ONGOING] - WARNING Warning 2'}},
+            {"status": None, "expected": [{'device.address': '1.2.3.4:1', 'level': 'WARN', 'message': '1.2.3.4:1: [ONGOING] - WARNING Warning 1'}, {'device.address': '1.2.3.4:2', 'level': 'WARN', 'message': '1.2.3.4:2: [ONGOING] - WARNING Warning 2'}]}
+        ]
+        
+        self.scheduler_thread.start()
+        time.sleep(0.1)
+
+        self.single_test_iteration(self.test_cases[0])
+
+        with freeze_time(datetime.now() + timedelta(hours=1), tick=True):
+            self.single_test_iteration(self.test_cases[1])
+
+            with freeze_time(datetime.now() + timedelta(hours=1), tick=True):
+                self.single_test_iteration(self.test_cases[2])
+
+                with freeze_time(datetime.now() + timedelta(hours=1), tick=True):
+                    self.single_test_iteration(self.test_cases[3])
+
+                    with freeze_time(datetime.now() + timedelta(hours=2), tick=True):
+                        self.single_test_iteration(self.test_cases[4])

--- a/tests/sdk/test_status.py
+++ b/tests/sdk/test_status.py
@@ -1,7 +1,9 @@
 import time
 import unittest
-from datetime import timedelta
+from datetime import timedelta, datetime
 from unittest.mock import MagicMock
+import threading
+from freezegun import freeze_time
 
 from dynatrace_extension import EndpointStatus, EndpointStatuses, Extension, Status, StatusValue
 from dynatrace_extension.sdk.communication import DebugClient, MultiStatus


### PR DESCRIPTION
- basic sfm sender
- each `EndpointStatus` has to be reported explicitly thorugh `EndpointStatuses` class
- deprecated `total_endpoints_number`
- sending SFM log per endpoint status change
- refactored building of overall status
- unit tests