### PR TITLE
DAQ-23741: replace floor(elapsed/interval) with iteration-based metri…

### DIFF
--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -140,7 +140,9 @@ class WrappedCallback:
         This guarantees each execution gets a unique timestamp spaced exactly one
         interval apart, and is immune to OS scheduling jitter.
         """
-        return self.start_timestamp + timedelta(seconds=self.interval.total_seconds() * max(self.executions_total - 1, 0))
+        return self.start_timestamp + timedelta(
+            seconds=self.interval.total_seconds() * max(self.executions_total - 1, 0)
+        )
 
     def clear_sfm_metrics(self):
         self.ok_count = 0

--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -135,14 +135,12 @@ class WrappedCallback:
         In this scenario a metric is reported twice in the same minute
         This can also cause minutes where a metric is not reported at all, creating gaps
 
-        Here we calculate the metric timestamp based on the start timestamp of the callback
-        If the callback started in the last minute, we use the callback start timestamp
-        between 60 seconds and 120 seconds, we use the callback timestamp + 1 minute
-        between 120 seconds and 180 seconds, we use the callback timestamp + 2 minutes, and so forth
+        The metric timestamp is derived from the callback's start time and its exact
+        iteration count: start_timestamp + (executions_total - 1) * interval.
+        This guarantees each execution gets a unique timestamp spaced exactly one
+        interval apart, and is immune to OS scheduling jitter.
         """
-        now = self.get_current_time_with_cluster_diff()
-        minutes_since_start = int((now - self.start_timestamp).total_seconds() / 60)
-        return self.start_timestamp + timedelta(minutes=minutes_since_start)
+        return self.start_timestamp + timedelta(seconds=self.interval.total_seconds() * max(self.executions_total - 1, 0))
 
     def clear_sfm_metrics(self):
         self.ok_count = 0

--- a/tests/sdk/test_callback.py
+++ b/tests/sdk/test_callback.py
@@ -39,25 +39,16 @@ class TestCallBack(unittest.TestCase):
 
         # In production, __call__ increments executions_total before each execution.
         # We set it manually here to simulate the state at the time get_adjusted_metric_timestamp() is called.
-        # 30 seconds later
+        # 1st execution: metric timestamp should match the callback start timestamp
         cb.executions_total = 1
-        cb.get_current_time_with_cluster_diff = MagicMock(return_value=datetime(2020, 1, 1, 0, 0, 30))
-
-        # The metric timestamp should match the callback start timestamp
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 0, 0))
 
-        # 1 minute 5 seconds later
+        # 2nd execution: metric timestamp should be start + 1 interval
         cb.executions_total = 2
-        cb.get_current_time_with_cluster_diff = MagicMock(return_value=datetime(2020, 1, 1, 0, 1, 5))
-
-        # The metric timestamp should match the callback start timestamp + 1 minute
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 1, 0))
 
-        # 4 minutes 55 seconds later
+        # 5th execution: metric timestamp should be start + 4 intervals
         cb.executions_total = 5
-        cb.get_current_time_with_cluster_diff = MagicMock(return_value=datetime(2020, 1, 1, 0, 4, 55))
-
-        # The metric timestamp should match the callback start timestamp + 4 minutes
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 4, 0))
 
     def test_metric_timestamp_synchronization_with_cluster_time(self):

--- a/tests/sdk/test_callback.py
+++ b/tests/sdk/test_callback.py
@@ -37,19 +37,24 @@ class TestCallBack(unittest.TestCase):
         cb = WrappedCallback(timedelta(minutes=1), callback, MagicMock(), running_in_sim=True)
         cb.start_timestamp = datetime(2020, 1, 1, 0, 0, 0)
 
+        # In production, __call__ increments executions_total before each execution.
+        # We set it manually here to simulate the state at the time get_adjusted_metric_timestamp() is called.
         # 30 seconds later
+        cb.executions_total = 1
         cb.get_current_time_with_cluster_diff = MagicMock(return_value=datetime(2020, 1, 1, 0, 0, 30))
 
         # The metric timestamp should match the callback start timestamp
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 0, 0))
 
         # 1 minute 5 seconds later
+        cb.executions_total = 2
         cb.get_current_time_with_cluster_diff = MagicMock(return_value=datetime(2020, 1, 1, 0, 1, 5))
 
         # The metric timestamp should match the callback start timestamp + 1 minute
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 1, 0))
 
         # 4 minutes 55 seconds later
+        cb.executions_total = 5
         cb.get_current_time_with_cluster_diff = MagicMock(return_value=datetime(2020, 1, 1, 0, 4, 55))
 
         # The metric timestamp should match the callback start timestamp + 4 minutes


### PR DESCRIPTION

Using floor(elapsed / interval) was susceptible to duplicate timestamps. 
When the ThreadPoolExecutor started a callback slightly before the interval boundary due to OS scheduling jitter (observed: 50–500ms early under load), two consecutive executions would receive the same timestamp, causing duplicate datapoints and missing datapoints in subsequent buckets.

Using (executions_total - 1) * interval is immune to scheduling jitter because it derives the timestamp from the logical iteration index rather than wall-clock elapsed time.
        
        Metric count is stable with fix 
        
<img width="2834" height="1040" alt="image" src="https://github.com/user-attachments/assets/58aa1a56-63a5-4d8a-b97a-a9d6e1d6114e" />

And it was like here:
<img width="1470" height="1035" alt="image" src="https://github.com/user-attachments/assets/ee5ee3fa-f308-4284-9850-c432f1a5bd58" />
