### PR TITLE
Add primary tags and primary fields helper methods and --no-index option #145

### DIFF
--- a/docs/guides/building.rst
+++ b/docs/guides/building.rst
@@ -28,7 +28,7 @@ Native dependencies
 | This means that your extension must be built on a machine that has the same version of python as the Activegate.
 |
 | Dynatrace extensions support **python 3.10** and **python 3.14**.
-| We plan to end support for **python 3.10** around October/2026.
+| We plan to `end support for python 3.10 soon`_, and suggest you migrate to **python 3.14**.
 |
 | When you build the extension with **dt-sdk build**, it downloads the dependencies **whl** files and places them in the lib folder of the extension.
 | To obtain whl files for different a operating system than what the build machine is, the SDK provides the **--extra-platform** flag.
@@ -137,3 +137,4 @@ Musl vs libc
 .. _charset-normalizer pypi page: https://pypi.org/project/charset-normalizer/#files
 .. _musl: https://musl.libc.org/
 .. _libc: https://en.wikipedia.org/wiki/C_standard_library
+.. _end support for python 3.10 soon: https://docs.dynatrace.com/docs/shortlink/python-extension-runtime-update

--- a/dynatrace_extension/__about__.py
+++ b/dynatrace_extension/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 
-__version__ = "1.9.7"
+__version__ = "1.9.8"

--- a/dynatrace_extension/cli/main.py
+++ b/dynatrace_extension/cli/main.py
@@ -130,6 +130,11 @@ def build(
         "-p",
         help=f"Python versions to download wheels for. Supported: {', '.join(SUPPORTED_PYTHON_VERSIONS)}",
     ),
+    no_index: bool = typer.Option(
+        False,
+        "--no-index",
+        help="Pass --no-index to pip, ignoring the package index (only --find-links sources will be used)",
+    ),
 ):
     """
     Builds and signs an extension using the developer fused key-certificate
@@ -144,6 +149,7 @@ def build(
     :param find_links: Extra index url to use when downloading dependencies
     :param only_extra_platforms: If true, only build for the extra platforms, useful when building from arm64
     :param python_versions: Python versions to download wheels for, defaults to ['3.10']
+    :param no_index: If true, pass --no-index to pip so only --find-links sources are used
     """
     console.print(f"Building and signing extension from {extension_dir} to {target_directory}", style="cyan")
     if target_directory is None:
@@ -152,7 +158,7 @@ def build(
         target_directory.mkdir()
 
     console.print("Stage 1 - Download and build dependencies", style="bold blue")
-    wheel(extension_dir, extra_platforms, extra_index_url, find_links, only_extra_platforms, python_versions)
+    wheel(extension_dir, extra_platforms, extra_index_url, find_links, only_extra_platforms, python_versions, no_index)
 
     console.print("Stage 2 - Create the extension zip file", style="bold blue")
     built_zip = assemble(extension_dir, target_directory)
@@ -270,6 +276,11 @@ def wheel(
         "-p",
         help=f"Python versions to download wheels for. Supported: {', '.join(SUPPORTED_PYTHON_VERSIONS)}",
     ),
+    no_index: bool = typer.Option(
+        False,
+        "--no-index",
+        help="Pass --no-index to pip, ignoring the package index (only --find-links sources will be used)",
+    ),
 ):
     """
     Builds the extension and it's dependencies into wheel files
@@ -281,12 +292,15 @@ def wheel(
     :param find_links: Extra index url to use when downloading dependencies
     :param only_extra_platforms: If true, only build for the extra platforms, useful when building from arm64
     :param python_versions: Python versions to download wheels for, defaults to ['3.10']
+    :param no_index: If true, pass --no-index to pip so only --find-links sources are used
     """
     # Handle OptionInfo objects when called directly (not via CLI)
     if python_versions is None or isinstance(python_versions, typer.models.OptionInfo):
         python_versions = ["3.10"]
     if only_extra_platforms is None or isinstance(only_extra_platforms, typer.models.OptionInfo):
         only_extra_platforms = False
+    if no_index is None or isinstance(no_index, typer.models.OptionInfo):
+        no_index = False
 
     # Validate python versions
     for version in python_versions:
@@ -309,6 +323,8 @@ def wheel(
         command.extend(["--extra-index-url", extra_index_url])
     if find_links is not None:
         command.extend(["--find-links", find_links])
+    if no_index:
+        command.append("--no-index")
     command.append(".")
     run_process(command, cwd=extension_dir)
 
@@ -332,6 +348,8 @@ def wheel(
                 command.extend(["--extra-index-url", extra_index_url])
             if find_links:
                 command.extend(["--find-links", find_links])
+            if no_index:
+                command.append("--no-index")
             command.append(".")
             run_process(command, cwd=extension_dir)
 
@@ -358,6 +376,8 @@ def wheel(
                     command.extend(["--extra-index-url", extra_index_url])
                 if find_links:
                     command.extend(["--find-links", find_links])
+                if no_index:
+                    command.append("--no-index")
                 command.append(".")
 
                 run_process(command, cwd=extension_dir)
@@ -386,6 +406,8 @@ def wheel(
                 command.extend(["--extra-index-url", extra_index_url])
             if find_links:
                 command.extend(["--find-links", find_links])
+            if no_index:
+                command.append("--no-index")
             command.extend(windows_deps)
             run_process(command, cwd=extension_dir)
 

--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -36,7 +36,7 @@ class WrappedCallback:
         self.logger = logger
         self.running: bool = False
         self.status = Status(StatusValue.OK)
-        self.executions_total = 0  # global counter
+        self.executions_total = 0  # global counter, counts actual callback executions
         self.executions_per_interval = 0  # counter per interval = 1 min by default
         self.duration = 0  # global counter
         self.duration_interval_total = 0  # counter per interval = 1 min by default
@@ -49,7 +49,7 @@ class WrappedCallback:
         self.timeouts_count = 0  # counter per interval = 1 min by default
         self.exception_count = 0  # counter per interval = 1 min by default
         self.iterations = 0  # how many times we ran the callback iterator for this callback
-        self.current_iteration = 0  # snapshot of `iterations` taken at the start of each execution
+        self.scheduled_iteration_snapshot = 0  # snapshot of `iterations` taken at the start of each execution
         self.offset_seconds = offset_seconds or self.calculate_initial_wait_time()
 
     def get_current_time_with_cluster_diff(self):
@@ -63,7 +63,7 @@ class WrappedCallback:
         # Snapshot the scheduler tick index so all metrics emitted during this
         # execution share one timestamp bucket, even if the next scheduler tick
         # fires while we are still running.
-        self.current_iteration = self.iterations
+        self.scheduled_iteration_snapshot = self.iterations
         start_time = timer()
         failed = False
         try:
@@ -140,7 +140,7 @@ class WrappedCallback:
 
         The metric timestamp is derived from the callback's start time and the
         scheduler tick index snapshotted at the start of this execution:
-        start_timestamp + (current_iteration - 1) * interval.
+        start_timestamp + (scheduled_iteration_snapshot - 1) * interval.
 
         We use the snapshot (taken in __call__) rather than the live `iterations`
         counter so that all metrics emitted during one execution share one
@@ -148,7 +148,7 @@ class WrappedCallback:
         `iterations`) while this run is still in progress.
         """
         return self.start_timestamp + timedelta(
-            seconds=self.interval.total_seconds() * max(self.current_iteration - 1, 0)
+            seconds=self.interval.total_seconds() * max(self.scheduled_iteration_snapshot - 1, 0)
         )
 
     def clear_sfm_metrics(self):

--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -141,9 +141,7 @@ class WrappedCallback:
         runs), so that timestamps stay aligned to wall-clock time even when a
         tick is skipped because the previous run exceeded the interval.
         """
-        return self.start_timestamp + timedelta(
-            seconds=self.interval.total_seconds() * max(self.iterations - 1, 0)
-        )
+        return self.start_timestamp + timedelta(seconds=self.interval.total_seconds() * max(self.iterations - 1, 0))
 
     def clear_sfm_metrics(self):
         self.ok_count = 0

--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -49,6 +49,7 @@ class WrappedCallback:
         self.timeouts_count = 0  # counter per interval = 1 min by default
         self.exception_count = 0  # counter per interval = 1 min by default
         self.iterations = 0  # how many times we ran the callback iterator for this callback
+        self.current_iteration = 0  # snapshot of `iterations` taken at the start of each execution
         self.offset_seconds = offset_seconds or self.calculate_initial_wait_time()
 
     def get_current_time_with_cluster_diff(self):
@@ -59,6 +60,10 @@ class WrappedCallback:
         self.running = True
         self.executions_total += 1
         self.executions_per_interval += 1
+        # Snapshot the scheduler tick index so all metrics emitted during this
+        # execution share one timestamp bucket, even if the next scheduler tick
+        # fires while we are still running.
+        self.current_iteration = self.iterations
         start_time = timer()
         failed = False
         try:
@@ -134,14 +139,17 @@ class WrappedCallback:
         This can also cause minutes where a metric is not reported at all, creating gaps
 
         The metric timestamp is derived from the callback's start time and the
-        scheduler tick index: start_timestamp + (iterations - 1) * interval.
+        scheduler tick index snapshotted at the start of this execution:
+        start_timestamp + (current_iteration - 1) * interval.
 
-        We use `iterations` (incremented by the scheduler on every tick) rather
-        than `executions_total` (incremented only when the callback actually
-        runs), so that timestamps stay aligned to wall-clock time even when a
-        tick is skipped because the previous run exceeded the interval.
+        We use the snapshot (taken in __call__) rather than the live `iterations`
+        counter so that all metrics emitted during one execution share one
+        timestamp bucket, even if the scheduler fires the next tick (bumping
+        `iterations`) while this run is still in progress.
         """
-        return self.start_timestamp + timedelta(seconds=self.interval.total_seconds() * max(self.iterations - 1, 0))
+        return self.start_timestamp + timedelta(
+            seconds=self.interval.total_seconds() * max(self.current_iteration - 1, 0)
+        )
 
     def clear_sfm_metrics(self):
         self.ok_count = 0

--- a/dynatrace_extension/sdk/callback.py
+++ b/dynatrace_extension/sdk/callback.py
@@ -56,8 +56,6 @@ class WrappedCallback:
 
     def __call__(self):
         self.logger.debug(f"Running scheduled callback {self}")
-        if self.executions_total == 0:
-            self.start_timestamp = self.get_current_time_with_cluster_diff()
         self.running = True
         self.executions_total += 1
         self.executions_per_interval += 1
@@ -135,13 +133,16 @@ class WrappedCallback:
         In this scenario a metric is reported twice in the same minute
         This can also cause minutes where a metric is not reported at all, creating gaps
 
-        The metric timestamp is derived from the callback's start time and its exact
-        iteration count: start_timestamp + (executions_total - 1) * interval.
-        This guarantees each execution gets a unique timestamp spaced exactly one
-        interval apart, and is immune to OS scheduling jitter.
+        The metric timestamp is derived from the callback's start time and the
+        scheduler tick index: start_timestamp + (iterations - 1) * interval.
+
+        We use `iterations` (incremented by the scheduler on every tick) rather
+        than `executions_total` (incremented only when the callback actually
+        runs), so that timestamps stay aligned to wall-clock time even when a
+        tick is skipped because the previous run exceeded the interval.
         """
         return self.start_timestamp + timedelta(
-            seconds=self.interval.total_seconds() * max(self.executions_total - 1, 0)
+            seconds=self.interval.total_seconds() * max(self.iterations - 1, 0)
         )
 
     def clear_sfm_metrics(self):

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -870,8 +870,13 @@ class Extension:
                 self._running_callbacks.pop(current_thread_id, None)
 
     def _callback_iteration(self, callback: WrappedCallback):
-        self._callbacks_executor.submit(self._run_callback, callback)
+        if callback.iterations == 0:
+            # Anchor the timestamp clock at the first tick (not at first execution),
+            # so reported metric timestamps stay aligned to scheduler ticks even when
+            # the executor is briefly backlogged at startup.
+            callback.start_timestamp = callback.get_current_time_with_cluster_diff()
         callback.iterations += 1
+        self._callbacks_executor.submit(self._run_callback, callback)
         next_timestamp = callback.get_next_execution_timestamp()
         self._scheduler.enterabs(next_timestamp, 1, self._callback_iteration, (callback,))
 

--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -1184,6 +1184,30 @@ class Extension:
         """Return the extension version."""
         return self.activation_config.version
 
+    def get_fields_dimensions(self, endpoint: dict) -> dict:
+        """Parse primaryFields from an endpoint dict into a dimensions dictionary.
+
+        Returns:
+            Dictionary mapping each field's 'key' to its 'value', or empty dict if absent.
+        """
+        return {e["key"]: e.get("value") for e in endpoint.get("primaryFields") or [] if "key" in e}
+
+    def get_tags_dimensions(self, endpoint: dict) -> dict:
+        """Parse primaryTags from an endpoint dict into a dimensions dictionary.
+
+        Returns:
+            Dictionary mapping each tag's 'key' to its 'value', or empty dict if absent.
+        """
+        return {e["key"]: e.get("value") for e in endpoint.get("primaryTags") or [] if "key" in e}
+
+    def get_tags_and_fields_dimensions(self, endpoint: dict) -> dict:
+        """Parse primaryFields and primaryTags from an endpoint dict into a merged dimensions dictionary.
+
+        Returns:
+            Merged dictionary from primaryFields and primaryTags entries.
+        """
+        return {**self.get_fields_dimensions(endpoint), **self.get_tags_dimensions(endpoint)}
+
     @property
     def techrule(self) -> str:
         """Internal property used by the EEC."""

--- a/tests/sdk/test_callback.py
+++ b/tests/sdk/test_callback.py
@@ -141,6 +141,61 @@ class TestCallBack(unittest.TestCase):
             self.assertEqual(cb.get_adjusted_metric_timestamp(), anchor + timedelta(seconds=60))
             self.assertEqual(cb.start_timestamp, anchor)
 
+    def test_metric_timestamps_within_one_execution_must_share_bucket(self):
+        """
+        Regression test:
+
+        All metrics reported from a single callback invocation must share one
+        timestamp (one "bucket" per run). Otherwise, when a long-running
+        callback spans a scheduler tick boundary, two metrics emitted within
+        the same `__call__` invocation get different timestamps — one before
+        the tick fires and one after — even though they belong to the same
+        logical execution.
+
+        Simulated sequence with interval=60s, callback runtime=70s:
+          T=0  : scheduler fires tick 1 → iterations=1, callback starts
+          T=10 : callback reports metric A
+          T=60 : scheduler fires tick 2 mid-execution → iterations=2 (run is skipped)
+          T=65 : same callback execution reports metric B
+          T=70 : callback finishes
+        """
+        interval = timedelta(minutes=1)
+        anchor = datetime(2026, 1, 1, 12, 0, 0)
+
+        timestamps: list[datetime] = []
+
+        with freeze_time(anchor) as frozen:
+            def long_running_callback():
+                # T=10: first metric reported within the run
+                frozen.tick(timedelta(seconds=10))
+                timestamps.append(cb.get_adjusted_metric_timestamp())
+
+                # T=60: scheduler fires the next tick mid-execution.
+                # extension._callback_iteration increments `iterations` even
+                # though _run_callback will skip the submission (running=True).
+                frozen.tick(timedelta(seconds=50))
+                cb.iterations += 1
+
+                # T=65: second metric reported within the SAME run
+                frozen.tick(timedelta(seconds=5))
+                timestamps.append(cb.get_adjusted_metric_timestamp())
+
+            cb = WrappedCallback(interval, long_running_callback, MagicMock(), running_in_sim=True)
+            cb.start_timestamp = anchor
+
+            # Scheduler tick 1: anchor + iterations bump, then run.
+            cb.iterations += 1
+            cb()
+
+        # Both metrics were emitted within run #1; they should share one bucket.
+        self.assertEqual(
+            timestamps[0],
+            timestamps[1],
+            f"Metrics from a single execution got different timestamps: "
+            f"A={timestamps[0]}, B={timestamps[1]}, "
+            f"jump = {(timestamps[1] - timestamps[0]).total_seconds()}s",
+        )
+
     def test_metric_timestamp_synchronization_with_cluster_time(self):
         def callback():
             pass

--- a/tests/sdk/test_callback.py
+++ b/tests/sdk/test_callback.py
@@ -39,19 +39,19 @@ class TestCallBack(unittest.TestCase):
         cb = WrappedCallback(timedelta(minutes=1), callback, MagicMock(), running_in_sim=True)
         cb.start_timestamp = datetime(2020, 1, 1, 0, 0, 0)
 
-        # In production, the scheduler increments `iterations` on every tick before
-        # the callback runs. We set it manually here to simulate that state at the
-        # time get_adjusted_metric_timestamp() is called.
-        # 1st tick: metric timestamp should match the callback start timestamp
-        cb.iterations = 1
+        # In production, __call__ snapshots `iterations` into `current_iteration`
+        # at the start of each execution. We set it manually here to simulate
+        # that state at the time get_adjusted_metric_timestamp() is called.
+        # 1st execution: metric timestamp should match the callback start timestamp
+        cb.current_iteration = 1
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 0, 0))
 
-        # 2nd tick: metric timestamp should be start + 1 interval
-        cb.iterations = 2
+        # 2nd execution: metric timestamp should be start + 1 interval
+        cb.current_iteration = 2
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 1, 0))
 
-        # 5th tick: metric timestamp should be start + 4 intervals
-        cb.iterations = 5
+        # 5th execution: metric timestamp should be start + 4 intervals
+        cb.current_iteration = 5
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 4, 0))
 
     def test_metric_timestamp_does_not_drift_when_execution_exceeds_interval(self):

--- a/tests/sdk/test_callback.py
+++ b/tests/sdk/test_callback.py
@@ -39,19 +39,19 @@ class TestCallBack(unittest.TestCase):
         cb = WrappedCallback(timedelta(minutes=1), callback, MagicMock(), running_in_sim=True)
         cb.start_timestamp = datetime(2020, 1, 1, 0, 0, 0)
 
-        # In production, __call__ snapshots `iterations` into `current_iteration`
+        # In production, __call__ snapshots `iterations` into `scheduled_iteration_snapshot`
         # at the start of each execution. We set it manually here to simulate
         # that state at the time get_adjusted_metric_timestamp() is called.
         # 1st execution: metric timestamp should match the callback start timestamp
-        cb.current_iteration = 1
+        cb.scheduled_iteration_snapshot = 1
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 0, 0))
 
         # 2nd execution: metric timestamp should be start + 1 interval
-        cb.current_iteration = 2
+        cb.scheduled_iteration_snapshot = 2
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 1, 0))
 
         # 5th execution: metric timestamp should be start + 4 intervals
-        cb.current_iteration = 5
+        cb.scheduled_iteration_snapshot = 5
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 4, 0))
 
     def test_metric_timestamp_does_not_drift_when_execution_exceeds_interval(self):

--- a/tests/sdk/test_callback.py
+++ b/tests/sdk/test_callback.py
@@ -165,6 +165,7 @@ class TestCallBack(unittest.TestCase):
         timestamps: list[datetime] = []
 
         with freeze_time(anchor) as frozen:
+
             def long_running_callback():
                 # T=10: first metric reported within the run
                 frozen.tick(timedelta(seconds=10))

--- a/tests/sdk/test_callback.py
+++ b/tests/sdk/test_callback.py
@@ -2,6 +2,8 @@ import unittest
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
+from freezegun import freeze_time
+
 from dynatrace_extension.sdk.callback import WrappedCallback
 
 
@@ -37,19 +39,107 @@ class TestCallBack(unittest.TestCase):
         cb = WrappedCallback(timedelta(minutes=1), callback, MagicMock(), running_in_sim=True)
         cb.start_timestamp = datetime(2020, 1, 1, 0, 0, 0)
 
-        # In production, __call__ increments executions_total before each execution.
-        # We set it manually here to simulate the state at the time get_adjusted_metric_timestamp() is called.
-        # 1st execution: metric timestamp should match the callback start timestamp
-        cb.executions_total = 1
+        # In production, the scheduler increments `iterations` on every tick before
+        # the callback runs. We set it manually here to simulate that state at the
+        # time get_adjusted_metric_timestamp() is called.
+        # 1st tick: metric timestamp should match the callback start timestamp
+        cb.iterations = 1
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 0, 0))
 
-        # 2nd execution: metric timestamp should be start + 1 interval
-        cb.executions_total = 2
+        # 2nd tick: metric timestamp should be start + 1 interval
+        cb.iterations = 2
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 1, 0))
 
-        # 5th execution: metric timestamp should be start + 4 intervals
-        cb.executions_total = 5
+        # 5th tick: metric timestamp should be start + 4 intervals
+        cb.iterations = 5
         self.assertEqual(cb.get_adjusted_metric_timestamp(), datetime(2020, 1, 1, 0, 4, 0))
+
+    def test_metric_timestamp_does_not_drift_when_execution_exceeds_interval(self):
+        """
+        Regression test for DAQ-23741 follow-up:
+
+        When a callback execution exceeds its interval, extension._run_callback
+        skips the next tick via the `if not callback.running` guard, so the
+        callback's __call__ — and thus executions_total — is not incremented
+        for the skipped tick.
+
+        get_adjusted_metric_timestamp() must therefore derive its timestamp
+        from `iterations` (incremented by the scheduler on every tick) rather
+        than `executions_total`, otherwise each skipped tick causes a permanent
+        `interval`-sized drift between metric timestamps and wall-clock time.
+        """
+        interval = timedelta(minutes=1)
+        start = datetime(2026, 1, 1, 12, 0, 0)
+
+        with freeze_time(start) as frozen:
+            cb = WrappedCallback(interval, lambda: None, MagicMock(), running_in_sim=True)
+            cb.start_timestamp = start
+
+            # Tick 1 fires at T=0. Scheduler increments iterations, callback runs
+            # (and takes 65s — longer than the interval).
+            cb.iterations += 1
+            cb()
+            frozen.tick(timedelta(seconds=65))
+
+            # Tick 2 fires at T=60 while the previous run is still in-flight.
+            # extension._callback_iteration still increments iterations, but
+            # extension._run_callback skips invoking the callback because
+            # cb.running is True. We mirror that here:
+            cb.iterations += 1
+            # (no cb() call — execution skipped)
+
+            # Tick 3 fires at T=120 — callback is free, runs again.
+            frozen.tick(timedelta(seconds=55))
+            cb.iterations += 1
+            cb()
+
+            reported = cb.get_adjusted_metric_timestamp()
+            wall_clock_now = datetime.now()
+
+            self.assertEqual(
+                reported,
+                wall_clock_now,
+                f"Metric timestamp drifted: reported {reported}, wall clock {wall_clock_now}, "
+                f"drift = {(wall_clock_now - reported).total_seconds()}s",
+            )
+
+    def test_start_timestamp_anchored_at_first_tick_not_first_execution(self):
+        """
+        Regression test:
+
+        `start_timestamp` must be anchored when the first scheduler tick fires,
+        not when the first execution actually runs in the worker. Otherwise a
+        backlogged executor at startup will shift `start_timestamp` forward
+        while `iterations` has already advanced, producing metric timestamps
+        in the future relative to wall-clock.
+
+        Simulated sequence:
+          T=0  : tick 1 fires → anchor start_timestamp, iterations=1, submit #1 (queued)
+          T=60 : tick 2 fires → iterations=2, submit #2 (queued)
+          T=30 (between): worker finally picks up #1 and runs the callback
+        """
+        interval = timedelta(minutes=1)
+        anchor = datetime(2026, 1, 1, 12, 0, 0)
+
+        with freeze_time(anchor) as frozen:
+            cb = WrappedCallback(interval, lambda: None, MagicMock(), running_in_sim=True)
+
+            # Tick 1 at T=0 — scheduler anchors start_timestamp here.
+            cb.start_timestamp = cb.get_current_time_with_cluster_diff()
+            cb.iterations += 1
+
+            # Tick 2 at T=60 — scheduler increments iterations even though
+            # the executor hasn't started run #1 yet.
+            frozen.tick(timedelta(seconds=60))
+            cb.iterations += 1
+
+            # Executor finally picks up run #1 somewhere in between.
+            # Calling cb() here must NOT re-anchor start_timestamp.
+            cb()
+
+            # The very first run's metric timestamp must equal the original anchor.
+            self.assertEqual(cb.get_adjusted_metric_timestamp(), anchor + timedelta(seconds=60))
+            self.assertEqual(cb.start_timestamp, anchor)
 
     def test_metric_timestamp_synchronization_with_cluster_time(self):
         def callback():

--- a/tests/sdk/test_extension.py
+++ b/tests/sdk/test_extension.py
@@ -975,3 +975,44 @@ def test_sfm_exception(mock_time):
         _verify_sfm_value(sfm, expected_values)
     finally:
         _teardown_extension()
+
+
+class TestGetTagsAndFieldsDimensions(unittest.TestCase):
+    def setUp(self):
+        self.extension = Extension()
+
+    def tearDown(self):
+        Extension._instance = None
+        Extension.schedule_decorators = []
+
+    def test_returns_merged_fields_and_tags(self):
+        endpoint = {
+            "name": "test",
+            "primaryFields": [{"key": "aws.account.id", "value": "aws_test"}],
+            "primaryTags": [{"key": "primary_tags.test_a", "value": "value_b"}],
+        }
+        result = self.extension.get_tags_and_fields_dimensions(endpoint)
+        assert result == {"aws.account.id": "aws_test", "primary_tags.test_a": "value_b"}
+
+    def test_returns_empty_dict_when_no_primary_fields_or_tags(self):
+        endpoint = {"name": "test", "login_url": "other"}
+        assert self.extension.get_tags_and_fields_dimensions(endpoint) == {}
+
+    def test_returns_empty_dict_for_empty_endpoint(self):
+        assert self.extension.get_tags_and_fields_dimensions({}) == {}
+
+    def test_get_fields_dimensions_only(self):
+        endpoint = {"primaryFields": [{"key": "aws.account.id", "value": "aws_test"}]}
+        assert self.extension.get_fields_dimensions(endpoint) == {"aws.account.id": "aws_test"}
+
+    def test_get_tags_dimensions_only(self):
+        endpoint = {"primaryTags": [{"key": "primary_tags.test_a", "value": "value_b"}]}
+        assert self.extension.get_tags_dimensions(endpoint) == {"primary_tags.test_a": "value_b"}
+
+    def test_entries_without_key_are_skipped(self):
+        endpoint = {"primaryFields": [{"value": "no_key_here"}, {"key": "valid.key", "value": "v"}]}
+        assert self.extension.get_fields_dimensions(endpoint) == {"valid.key": "v"}
+
+    def test_null_lists_treated_as_empty(self):
+        endpoint = {"primaryFields": None, "primaryTags": None}
+        assert self.extension.get_tags_and_fields_dimensions(endpoint) == {}


### PR DESCRIPTION
These are helper methods to extract dimensions/properties from the user defined primaryTags and primaryFields from an endpoint.

Example, from an endpoint like:

```json
{
            "name": "test",
            "login_url": "other",
            "capture_mode": "event_streaming",
            "log_level": "INFO",
            "primaryFields": [
              {
                "key": "aws.account.id",
                "value": "aws_test"
              }
            ],
            "primaryTags": [
              {
                "key": "primary_tags.test_a",
                "value": "value_b"
              }
            ],
            "instance_url": "https://[MyDomain].my.salesforce.com"
}
```

`get_tags_and_fields_dimensions` will return:


```json
 {
    "primary_tags.test_a": "value_b",
    "aws.account.id": "aws_test"
}
```

Note that the endpoint must have primaryTags and primaryFields definitions for this to return anything.

This also adds `get_tags_dimensions` and `get_fields_dimensions`, in case the user wants to only add one of these to metrics/logs/events. Example, local extensions might not want to define primary fields

Finally we needed to change the logic in #146 because `execution_count` does not increment if the callback is skipped, causing it to not be an accurate way of getting a metric timestamp.