### PR TITLE
feat: allow initialize() to return Status to signal startup failure

### DIFF
--- a/dynatrace_extension/sdk/extension.py
+++ b/dynatrace_extension/sdk/extension.py
@@ -426,13 +426,20 @@ class Extension:
         """
         return IgnoreStatus()
 
-    def initialize(self):
+    def initialize(self) -> "Status | None":
         """Callback to be executed when the extension starts.
 
         Called once after the extension starts and the processes arguments are parsed.
         Sometimes there are tasks the user needs to do that must happen before runtime,
         but after the activation config has been received, example: Setting the schedule frequency
-        based on the user input on the monitoring configuration, this can be done on this method
+        based on the user input on the monitoring configuration, this can be done on this method.
+
+        Returns:
+            None or Status(StatusValue.OK) to indicate successful initialization.
+            A Status with any error StatusValue to abort startup — the status is sent to
+            EEC immediately and the extension process exits. During fastcheck the return
+            value is available to the caller of initialize() and should be forwarded as
+            the fastcheck result.
         """
         pass
 
@@ -814,9 +821,10 @@ class Extension:
         self.extension_version = self.activation_config.version
 
         if not self._is_fastcheck:
+            init_status = None
             try:
                 self._heartbeat_iteration()
-                self.initialize()
+                init_status = self.initialize()
                 if not self.is_helper:
                     self.schedule(self.query, timedelta(minutes=1))
             except Exception as e:
@@ -825,6 +833,12 @@ class Extension:
                 self._client.send_status(Status(StatusValue.GENERIC_ERROR, msg))
                 self._initialization_error = msg
                 raise e
+            if isinstance(init_status, Status) and init_status.is_error():
+                api_logger.error(f"self.initialize returned error status for {self}: {init_status}")
+                self._client.send_status(init_status)
+                self._initialization_error = init_status.message
+                msg = f"initialize() returned error status: {init_status.message}"
+                raise RuntimeError(msg)
 
     @property
     def _metadata(self) -> dict:

--- a/tests/sdk/test_extension.py
+++ b/tests/sdk/test_extension.py
@@ -486,6 +486,41 @@ class TestExtension(unittest.TestCase):
         with pytest.raises(AttributeError):
             MyExtension()
 
+    def test_initialize_returning_error_status_aborts_startup(self):
+        class MyExtension(Extension):
+            def initialize(self):
+                return Status(StatusValue.DEVICE_CONNECTION_ERROR, "cannot reach host")
+
+        with pytest.raises(RuntimeError, match="initialize\\(\\) returned error status"):
+            MyExtension()
+
+    def test_initialize_returning_error_status_sends_status_to_eec(self):
+        class MyExtension(Extension):
+            def initialize(self):
+                return Status(StatusValue.INVALID_CONFIG_ERROR, "bad config")
+
+        sent: list[Status] = []
+        with patch("dynatrace_extension.sdk.communication.DebugClient.send_status", side_effect=sent.append):
+            with pytest.raises(RuntimeError):
+                MyExtension()
+        assert any(s.status == StatusValue.INVALID_CONFIG_ERROR and "bad config" in s.message for s in sent)
+
+    def test_initialize_returning_none_starts_normally(self):
+        class MyExtension(Extension):
+            def initialize(self):
+                return None
+
+        ext = MyExtension()
+        assert ext._initialization_error == ""
+
+    def test_initialize_returning_ok_status_starts_normally(self):
+        class MyExtension(Extension):
+            def initialize(self):
+                return Status(StatusValue.OK)
+
+        ext = MyExtension()
+        assert ext._initialization_error == ""
+
     def test_report_mint_and_log_sending_failure(self):
         extension = get_helper_extension()
         extension.extension_logger = MagicMock()


### PR DESCRIPTION
When initialize() raises, the SDK wraps the exception in a generic "Python datasource fastcheck error" message, stripping the operator- facing context needed to diagnose the problem.

Allow initialize() to return Status | None. A None or OK status keeps the existing behaviour. An error Status is sent to EEC immediately with the correct StatusValue and message, then the process exits cleanly without the SDK overwriting it with a generic error.

This lets extensions map specific failure modes (SSL, auth, bad config) to the right StatusValue and write actionable messages once in initialize(), instead of duplicating try/except logic in fastcheck().

Closes #148